### PR TITLE
Make tour card avatars responsive

### DIFF
--- a/css/theme-premium.css
+++ b/css/theme-premium.css
@@ -688,6 +688,7 @@ html, body {
   flex-shrink: 0;
 }
 .tour-avatar + .tour-avatar { margin-left: -6px; }
+.tour-avatar-hidden { display: none !important; }
 
 .tour-avatar-admin  { background: #4a9eff; color: #001a40; }
 .tour-avatar-member { background: var(--accent); color: #0a0a0d; }
@@ -696,6 +697,9 @@ html, body {
   color: var(--accent) !important;
   font-size: 8px !important;
   border-color: var(--surface) !important;
+  width: auto !important;
+  min-width: 22px;
+  padding: 0 4px;
 }
 
 .tour-card-actions {

--- a/js/app.js
+++ b/js/app.js
@@ -313,6 +313,51 @@ function _canForegroundRefresh() {
   return ['communities', 'community-home', 'planning', 'community-media', 'tour'].includes(state.view);
 }
 
+function fitTourCardAvatars() {
+  document.querySelectorAll('[data-tour-avatar-stack]').forEach(stack => {
+    const actions = stack.closest('.tour-card-actions');
+    const footer = stack.closest('.tour-card-footer');
+    if (!actions || !footer) return;
+
+    const items = [...stack.querySelectorAll('[data-tour-avatar-item]')];
+    const more = stack.querySelector('[data-tour-avatar-more]');
+    if (!items.length || !more) return;
+
+    const footerStyle = getComputedStyle(footer);
+    const footerContentWidth = footer.getBoundingClientRect().width
+      - parseFloat(footerStyle.paddingLeft || 0)
+      - parseFloat(footerStyle.paddingRight || 0);
+    const actionsGap = parseFloat(getComputedStyle(actions).columnGap || getComputedStyle(actions).gap || 0) || 0;
+    const minDateWidth = 78;
+    const maxActionsWidth = Math.max(48, footerContentWidth - minDateWidth - actionsGap);
+
+    const applyVisibleCount = (count) => {
+      items.forEach((item, index) => {
+        item.classList.toggle('tour-avatar-hidden', index >= count);
+      });
+      const hiddenCount = items.length - count;
+      more.classList.toggle('tour-avatar-hidden', hiddenCount <= 0);
+      more.textContent = hiddenCount > 0 ? `+${hiddenCount}` : '';
+      more.title = hiddenCount > 0 ? `${hiddenCount} weitere Rider` : '';
+    };
+
+    const actionsWidthForCurrentState = () => {
+      const visibleChildren = [...actions.children].filter(child => {
+        if (child === stack) return true;
+        return getComputedStyle(child).display !== 'none' && !child.classList.contains('tour-avatar-hidden');
+      });
+      const childWidth = visibleChildren.reduce((sum, child) => sum + child.getBoundingClientRect().width, 0);
+      return childWidth + Math.max(0, visibleChildren.length - 1) * actionsGap;
+    };
+
+    for (let count = items.length; count >= 1; count--) {
+      applyVisibleCount(count);
+      if (actionsWidthForCurrentState() <= maxActionsWidth) return;
+    }
+    applyVisibleCount(1);
+  });
+}
+
 async function refreshCurrentView({ force = false } = {}) {
   if (!_canForegroundRefresh()) return;
   const now = Date.now();
@@ -383,6 +428,7 @@ function render() {
     app.innerHTML = html;
     attachEvents();
     syncStickyLayout();
+    requestAnimationFrame(fitTourCardAvatars);
   } catch (e) {
     console.error('[render] error:', e);
     app.innerHTML = `<div style="padding:40px;color:#e04444;font-family:monospace">
@@ -571,7 +617,10 @@ function _withTimeout(promise, ms) {
  * Checks for an existing Supabase session and routes accordingly.
  */
 async function init() {
-  window.addEventListener('resize', syncStickyLayout);
+  window.addEventListener('resize', () => {
+    syncStickyLayout();
+    fitTourCardAvatars();
+  });
 
   // ─── State-Persistenz: Auto-Save bei Hintergrund/Schließen ────────
   // Wenn die App in den Hintergrund geht, State in localStorage sichern.

--- a/js/render.js
+++ b/js/render.js
@@ -475,21 +475,14 @@ function renderTourCard(tour, locked) {
   const memberUserIds = (state.tourMemberIds?.[tour.id] || [])
     .filter(uid => uid !== tour.admin_id);
 
-  // Adaptive avatar stack: admin first, then up to MAX_AVATARS-1 real members
-  const MAX_AVATARS = 5;
-  const visibleMemberIds = memberUserIds.slice(0, MAX_AVATARS - 1);
-  const overflowCount = Math.max(0, memberUserIds.length - visibleMemberIds.length);
-
   // Initials are computed community-wide via getInitials() →
   // Mario = MR, Manuel = MN, regardless of which tour they appear in.
-  let avatarStack = `<span class="tour-avatar tour-avatar-admin" title="${esc(adminName)}">${getInitials(tour.admin_id)}</span>`;
-  for (const uid of visibleMemberIds) {
+  let avatarStack = `<span class="tour-avatar tour-avatar-admin" data-tour-avatar-item title="${esc(adminName)}">${getInitials(tour.admin_id)}</span>`;
+  for (const uid of memberUserIds) {
     const name = state.profileCache[uid] || '?';
-    avatarStack += `<span class="tour-avatar tour-avatar-member" title="${esc(name)}">${getInitials(uid)}</span>`;
+    avatarStack += `<span class="tour-avatar tour-avatar-member" data-tour-avatar-item title="${esc(name)}">${getInitials(uid)}</span>`;
   }
-  if (overflowCount > 0) {
-    avatarStack += `<span class="tour-avatar tour-avatar-more">+${overflowCount}</span>`;
-  }
+  avatarStack += '<span class="tour-avatar tour-avatar-more tour-avatar-hidden" data-tour-avatar-more></span>';
 
   const kmPct = distanceClean !== '—' ? Math.min(100, Math.round((parseFloat(distanceClean) / 500) * 100)) : 35;
   const stripeColor = isMine ? 'var(--accent)' : 'var(--orange)';
@@ -593,7 +586,7 @@ function renderTourCard(tour, locked) {
     <div class="tour-card-date">${dateDisplay}</div>
     <div class="tour-card-actions">
       ${badgesHtml}
-      <div class="tour-card-avatars">${avatarStack}</div>
+      <div class="tour-card-avatars" data-tour-avatar-stack>${avatarStack}</div>
       <button class="btn-copy-link" data-copy-id="${tour.id}" title="Einladungslink kopieren" aria-label="Link kopieren">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
       </button>


### PR DESCRIPTION
## Summary
- render all tour-card rider avatars and collapse overflow dynamically based on available footer space
- add a hidden avatar class so collapsed avatars are actually removed from layout
- keep existing collision-aware initials logic unchanged

## Checks
- node --check js/app.js
- node --check js/render.js