### PR TITLE
[codex] Fix duplicate tour changelog entries

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -186,7 +186,7 @@ function computeTabBadges(tourId) {
 
   /* ── Changelog ── */
   const seenLog  = getLastSeen(tourId, 'changelog');
-  const newLog   = state.tourChangelog.filter(e => new Date(e.created_at) > seenLog);
+  const newLog   = _dedupeLogEntries(state.tourChangelog.filter(e => new Date(e.created_at) > seenLog));
   if (newLog.length) {
     state.tabBadges.changelog = newLog.map(e => ({
       text: `${e.username} → ${e.field}`,
@@ -196,7 +196,7 @@ function computeTabBadges(tourId) {
 
   /* ── Info (tour data changes since last visit) ── */
   const seenInfo = getLastSeen(tourId, 'info');
-  const infoLog  = state.tourChangelog.filter(e => new Date(e.created_at) > seenInfo);
+  const infoLog  = _dedupeLogEntries(state.tourChangelog.filter(e => new Date(e.created_at) > seenInfo));
   if (infoLog.length) {
     state.tabBadges.info = infoLog.map(e => ({
       text: `${e.field}: ${e.new_value || '—'}`,
@@ -213,6 +213,26 @@ function computeTabBadges(tourId) {
       time: new Date(m.created_at),
     }));
   }
+}
+
+function _dedupeLogEntries(entries, windowMs = 2 * 60 * 1000) {
+  const seen = new Map();
+  return (entries || []).filter(e => {
+    const key = [
+      e.tour_id || '',
+      e.user_id || e.username || '',
+      e.field || '',
+      e.old_value || '',
+      e.new_value || '',
+    ].join('\u0001');
+    const ts = new Date(e.created_at).getTime();
+    const previousTs = seen.get(key);
+    if (Number.isFinite(previousTs) && Number.isFinite(ts) && Math.abs(previousTs - ts) <= windowMs) {
+      return false;
+    }
+    seen.set(key, ts);
+    return true;
+  });
 }
 
 /**
@@ -233,9 +253,29 @@ async function loadChangelog() {
  * @param {string} oldValue
  * @param {string} newValue
  */
+const _recentLogWrites = new Map();
+const LOG_DEDUPE_WINDOW_MS = 5000;
+
 async function logChange(field, oldValue, newValue) {
   if (String(oldValue || '') === String(newValue || '')) return;
-  await sb.from('change_log').insert({
+
+  const now = Date.now();
+  for (const [key, ts] of _recentLogWrites) {
+    if (now - ts > LOG_DEDUPE_WINDOW_MS) _recentLogWrites.delete(key);
+  }
+
+  const logKey = [
+    state.currentTourId || '',
+    state.currentUser?.id || state.currentUser?.username || '',
+    field || '',
+    String(oldValue || ''),
+    String(newValue || ''),
+  ].join('\u0001');
+
+  if (_recentLogWrites.has(logKey)) return;
+  _recentLogWrites.set(logKey, now);
+
+  const { error } = await sb.from('change_log').insert({
     tour_id:   state.currentTourId,
     user_id:   state.currentUser.id,
     username:  state.currentUser.username,
@@ -243,6 +283,10 @@ async function logChange(field, oldValue, newValue) {
     old_value: String(oldValue || ''),
     new_value: String(newValue || ''),
   });
+  if (error) {
+    _recentLogWrites.delete(logKey);
+    throw new Error(error.message);
+  }
 }
 
 /**
@@ -291,8 +335,10 @@ async function joinTour(tourId) {
     .from('tour_members')
     .insert({ tour_id: tourId, user_id: state.currentUser.id });
 
-  if (error && !error.message.includes('duplicate')) throw new Error(error.message);
+  const alreadyMember = !!error && error.message.includes('duplicate');
+  if (error && !alreadyMember) throw new Error(error.message);
   state.myTourIds.add(tourId);
+  if (alreadyMember) return;
 
   // Log join
   const savedId = state.currentTourId;

--- a/js/events.js
+++ b/js/events.js
@@ -785,6 +785,8 @@ function attachEvents() {
   /* --- Tour tabs (only wire up when on tour view) --- */
   /* --- Overview cards → switch to the target tab --- */
   document.querySelectorAll('[data-go-tab]').forEach(card => {
+    if (card.dataset.goTabAttached === '1') return;
+    card.dataset.goTabAttached = '1';
     card.addEventListener('click', async () => {
       const tab = card.dataset.goTab;
       if (!tab) return;
@@ -849,12 +851,17 @@ function afterTabRender() {
   if (state.currentTab === 'overview') {
     // Re-attach card click handlers (attachEvents() only runs on full render)
     document.querySelectorAll('[data-go-tab]').forEach(card => {
+      if (card.dataset.goTabAttached === '1') return;
+      card.dataset.goTabAttached = '1';
       card.addEventListener('click', async () => {
         const tab = card.dataset.goTab;
         if (!tab) return;
         state.currentTab = tab;
         if (tab === 'chat')      await loadMessages();
         if (tab === 'changelog') await loadChangelog();
+        if (tab === 'info' && state.tabBadges.info?.length) {
+          state.infoBannerItems = state.tabBadges.info;
+        }
         markTabSeen(state.currentTourId, tab);
         computeTabBadges(state.currentTourId);
         _refreshTabBar();
@@ -970,6 +977,9 @@ function _refreshTabBar() {
       state.currentTab = btn.dataset.tab;
       if (state.currentTab === 'chat')      await loadMessages();
       if (state.currentTab === 'changelog') await loadChangelog();
+      if (state.currentTab === 'info' && state.tabBadges.info?.length) {
+        state.infoBannerItems = state.tabBadges.info;
+      }
       markTabSeen(state.currentTourId, state.currentTab);
       computeTabBadges(state.currentTourId);
       _refreshTabBar();
@@ -1053,6 +1063,10 @@ function _updateFsUi(container, isFs) {
 }
 
 function attachMapEvents() {
+  const mapContainer = document.getElementById('map-container');
+  if (mapContainer?.dataset.eventsAttached === '1') return;
+  if (mapContainer) mapContainer.dataset.eventsAttached = '1';
+
   /* Fullscreen toggle — CSS-based for mobile compatibility (iOS Safari
      does not support requestFullscreen on non-video elements) */
   document.getElementById('map-fullscreen')?.addEventListener('click', () => {
@@ -1117,18 +1131,22 @@ function attachMapEvents() {
 
   /* GPX upload (admin only) */
   document.getElementById('gpx-up')?.addEventListener('change', async e => {
+    if (e.target.dataset.busy === '1') return;
     const file = e.target.files[0];
     if (!file) return;
-
-    const text = await file.text();
-    const data = parseGPX(text);
-
-    const totalPts = data.tracks.reduce((s, t) => s + t.points.length, 0);
-    if (!totalPts && !data.waypoints.length) {
-      toast('Keine Route oder Wegpunkte in GPX-Datei gefunden.', 'error'); return;
-    }
+    e.target.dataset.busy = '1';
 
     try {
+      const text = await file.text();
+      const data = parseGPX(text);
+
+      const totalPts = data.tracks.reduce((s, t) => s + t.points.length, 0);
+      if (!totalPts && !data.waypoints.length) {
+        toast('Keine Route oder Wegpunkte in GPX-Datei gefunden.', 'error');
+        delete e.target.dataset.busy;
+        return;
+      }
+
       toast('Route wird gespeichert, Offroad-Anteil wird berechnet…');
       const result = await saveGPX(data, text);
       const summary = [
@@ -1138,7 +1156,10 @@ function attachMapEvents() {
       const offRoad = formatOffRoadPercentage(result?.surfaceAnalysis?.total);
       toast(`✓ Gespeichert: ${summary}${offRoad ? ` · ${offRoad}` : ' · Offroad-Analyse später erneut versuchen'}`);
       _refreshMapTab();
-    } catch (e) { toast(e.message, 'error'); }
+    } catch (e) {
+      toast(e.message, 'error');
+      delete e.target.dataset.busy;
+    }
   });
 
   document.getElementById('gpx-dl')?.addEventListener('click', () => {
@@ -1146,13 +1167,19 @@ function attachMapEvents() {
   });
 
   /* Delete route (admin only) */
-  document.getElementById('gpx-del')?.addEventListener('click', async () => {
+  document.getElementById('gpx-del')?.addEventListener('click', async e => {
+    const btn = e.currentTarget;
+    if (btn?.dataset.busy === '1') return;
+    if (btn) btn.dataset.busy = '1';
     try {
       await deleteGPX();
       clearRouteFromMap();
       toast('Route gelöscht');
       _refreshMapTab();
-    } catch (e) { toast(e.message, 'error'); }
+    } catch (e) {
+      toast(e.message, 'error');
+      if (btn) delete btn.dataset.busy;
+    }
   });
 }
 

--- a/js/render.js
+++ b/js/render.js
@@ -978,7 +978,9 @@ function renderCalWidget() {
    ---------------------------------------------------------- */
 
 function renderChangelogTab() {
-  const entries = state.tourChangelog;
+  const entries = typeof _dedupeLogEntries === 'function'
+    ? _dedupeLogEntries(state.tourChangelog)
+    : state.tourChangelog;
 
   if (!entries.length) {
     return `<div class="tab-scroll"><div style="padding:40px;text-align:center;color:var(--muted)">


### PR DESCRIPTION
## Summary
- Prevent duplicate tour changelog writes when repeated handlers or repeated join attempts fire the same action.
- Deduplicate near-identical changelog rows in badges, the info banner, and the log tab display.
- Make GPX map event wiring idempotent and guard route upload/delete actions with busy flags.

## Root Cause
Map tab initialization could bind GPX upload/delete handlers more than once, so one user action could call saveGPX() or deleteGPX() multiple times. Rejoining an already joined tour also ignored the duplicate membership error but still wrote a changelog entry.

## Validation
- node --check js/api.js
- node --check js/events.js
- node --check js/render.js