### PR TITLE
Add tour weather and synced seen state

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2519,6 +2519,40 @@ select option       { background: var(--surface2); }
 .tov-log-text { font-size: 12px; color: var(--muted-strong);
                 overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
+/* Weather card */
+.tov-weather-body { display: flex; flex-direction: column; gap: 7px; }
+.tov-weather-location {
+  color: var(--accent); font-size: 12px; font-weight: 700;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.tov-weather-main { display: flex; align-items: center; gap: 8px; }
+.tov-weather-icon { font-size: 24px; line-height: 1; }
+.tov-weather-temp {
+  font-family: var(--font-mono); font-size: 18px; font-weight: 800; color: var(--text);
+}
+.tov-weather-rain {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 800; color: var(--muted);
+}
+.tov-weather-na {
+  font-family: var(--font-display); font-size: 26px; font-weight: 800;
+  color: var(--muted); letter-spacing: .4px;
+}
+.tov-weather-na-hint {
+  font-size: 11px; line-height: 1.35; color: var(--muted);
+}
+.tov-weather-index {
+  border-top: 1px solid var(--border); padding-top: 7px;
+  font-family: var(--font-mono); font-size: 10px; color: var(--muted);
+}
+.tov-weather-index strong {
+  display: block; font-family: var(--font-display); font-size: 18px;
+  letter-spacing: .4px; text-transform: uppercase;
+}
+.tov-weather-index.offroad-wetness-dry strong { color: #4ade80; }
+.tov-weather-index.offroad-wetness-damp strong { color: var(--accent); }
+.tov-weather-index.offroad-wetness-wet strong { color: #ffb020; }
+.tov-weather-index.offroad-wetness-heavy strong { color: #e04444; }
+
 /* Badge in overview eyebrow */
 .tov-badge {
   display: inline-flex; align-items: center; justify-content: center;

--- a/css/theme-premium.css
+++ b/css/theme-premium.css
@@ -915,6 +915,382 @@ html, body {
   color: var(--text);
   letter-spacing: 0.02em;
 }
+.checkin-wd-rainprob,
+.checkin-wd-rain {
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+.checkin-wd-rainprob { color: var(--accent); }
+.checkin-wd-rain { color: var(--muted); }
+.checkin-weather-confidence {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.checkin-weather-confidence-high { color: #4ade80; }
+.checkin-weather-confidence-medium { color: var(--accent); }
+.checkin-weather-confidence-low { color: #ffb020; }
+
+/* ---------- TOUR WEATHER TAB ---------- */
+.tour-weather-layout {
+  padding: 24px;
+  max-width: 860px;
+}
+.tour-weather-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+.tour-weather-head h2 {
+  font-family: var(--font-display);
+  font-size: 28px;
+  letter-spacing: 1px;
+  margin: 0;
+}
+.tour-weather-select-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 240px;
+}
+.tour-weather-select-wrap span {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+.tour-weather-location {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
+}
+.tour-weather-location span:first-child {
+  color: var(--accent);
+  font-weight: 800;
+}
+.tour-weather-points {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.tour-weather-point {
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+.tour-weather-point:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+.tour-weather-point-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
+}
+.tour-weather-point-head strong {
+  color: var(--accent);
+  font-weight: 900;
+  letter-spacing: 0.04em;
+}
+.tour-weather-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 8px;
+}
+.tour-weather-day {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 8px;
+  text-align: center;
+}
+.tour-weather-date,
+.tour-weather-temp,
+.tour-weather-rain,
+.tour-weather-mm,
+.weather-loading,
+.weather-empty {
+  font-family: var(--font-mono);
+}
+.tour-weather-date {
+  font-size: 10px;
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.tour-weather-icon {
+  font-size: 24px;
+  line-height: 1;
+  margin: 7px 0;
+}
+.tour-weather-temp {
+  font-size: 13px;
+  color: var(--text);
+  font-weight: 800;
+}
+.tour-weather-segments {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-top: 7px;
+}
+.tour-weather-segment {
+  display: grid;
+  grid-template-columns: 22px 1fr 1fr;
+  gap: 4px;
+  align-items: baseline;
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  font-weight: 700;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.tour-weather-segment span:first-child {
+  color: var(--accent);
+  font-weight: 900;
+}
+.tour-weather-segment span:nth-child(2) {
+  color: var(--accent);
+}
+.weather-loading,
+.weather-empty {
+  color: var(--muted);
+  font-size: 12px;
+}
+.offroad-wetness {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--muted);
+  border-radius: var(--radius);
+}
+.offroad-wetness-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+.offroad-wetness strong {
+  font-family: var(--font-display);
+  font-size: 20px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.offroad-wetness-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--muted);
+}
+.offroad-wetness-dry { border-left-color: #4ade80; }
+.offroad-wetness-damp { border-left-color: var(--accent); }
+.offroad-wetness-wet { border-left-color: #ffb020; }
+.offroad-wetness-heavy { border-left-color: #e04444; }
+.offroad-wetness-dry strong { color: #4ade80; }
+.offroad-wetness-damp strong { color: var(--accent); }
+.offroad-wetness-wet strong { color: #ffb020; }
+.offroad-wetness-heavy strong { color: #e04444; }
+.offroad-wetness-matrix-wrap {
+  width: 100%;
+  max-width: 100%;
+  margin: 0 0 16px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface2);
+}
+.offroad-wetness-matrix {
+  width: 100%;
+  min-width: 640px;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+.offroad-wetness-matrix-title {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+.offroad-wetness-matrix td {
+  width: 1%;
+  min-width: 104px;
+  padding: 7px 8px;
+  border-right: 1px solid var(--border);
+  font-family: var(--font-mono);
+  text-align: center;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  vertical-align: middle;
+}
+.offroad-wetness-matrix td:last-child { border-right: none; }
+.offroad-wetness-matrix-names td {
+  color: var(--text);
+  font-size: 10px;
+  font-weight: 900;
+  line-height: 1.2;
+}
+.offroad-wetness-matrix-scores td {
+  border-top: 1px solid var(--border);
+  font-family: var(--font-display);
+  font-size: clamp(11px, 1.35vw, 14px);
+  letter-spacing: 0;
+  text-transform: uppercase;
+  line-height: 1.05;
+}
+.offroad-wetness-matrix-history td {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 800;
+  line-height: 1.25;
+}
+.offroad-wetness-matrix-history span {
+  display: block;
+}
+.offroad-wetness-matrix .offroad-wetness-dry { color: #4ade80; }
+.offroad-wetness-matrix .offroad-wetness-damp { color: var(--accent); }
+.offroad-wetness-matrix .offroad-wetness-wet { color: #ffb020; }
+.offroad-wetness-matrix .offroad-wetness-heavy { color: #e04444; }
+.offroad-wetness-matrix-names .offroad-wetness-dry,
+.offroad-wetness-matrix-names .offroad-wetness-damp,
+.offroad-wetness-matrix-names .offroad-wetness-wet,
+.offroad-wetness-matrix-names .offroad-wetness-heavy {
+  color: var(--text);
+}
+.tour-weather-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+.rain-radar-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(5, 5, 8, 0.78);
+}
+.rain-radar-modal {
+  width: min(980px, 100%);
+  height: min(720px, calc(100vh - 36px));
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.rain-radar-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.rain-radar-title {
+  font-family: var(--font-display);
+  font-size: 24px;
+  letter-spacing: 1px;
+  color: var(--text);
+}
+.rain-radar-sub,
+.rain-radar-foot {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
+}
+.rain-radar-close {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface2);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+.rain-radar-map {
+  flex: 1;
+  min-height: 360px;
+}
+.rain-radar-controls {
+  display: grid;
+  grid-template-columns: 34px 34px 1fr 34px;
+  gap: 8px;
+  align-items: center;
+  padding: 9px 12px;
+  border-top: 1px solid var(--border);
+  background: var(--surface2);
+}
+.rain-radar-step {
+  width: 34px;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--accent);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-weight: 900;
+}
+.rain-radar-step:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+#rain-radar-range {
+  width: 100%;
+  accent-color: var(--accent);
+}
+.rain-radar-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border);
+}
+.rain-radar-foot a {
+  color: var(--accent);
+  text-decoration: none;
+}
 
 /* ---------- WEATHER FORECAST HINT ---------- */
 .checkin-weather-hint {

--- a/js/api.js
+++ b/js/api.js
@@ -4,6 +4,54 @@
    ============================================================ */
 
 /* ----------------------------------------------------------
+   User seen-state (badges / banners)
+   ---------------------------------------------------------- */
+
+function _cacheSeenStateRow(row) {
+  if (!row?.scope_id || !row?.seen_key || !row?.seen_at) return;
+  if (!state.seenState) state.seenState = {};
+  const userId = row.user_id || state.currentUser?.id;
+  state.seenState[_seenCacheKey(row.scope_id, row.seen_key, userId)] = row.seen_at;
+  try { localStorage.setItem(_seenKey(row.scope_id, row.seen_key, userId), row.seen_at); } catch(e) {}
+}
+
+async function loadSeenStates(scopeIds) {
+  if (!state.currentUser || !navigator.onLine) return;
+  if (typeof migrateLegacySeenStateForCurrentUser === 'function') {
+    migrateLegacySeenStateForCurrentUser();
+  }
+  const ids = [...new Set((Array.isArray(scopeIds) ? scopeIds : [scopeIds]).filter(Boolean).map(String))];
+  if (!ids.length) return;
+
+  const { data, error } = await sb
+    .from('user_seen_state')
+    .select('user_id,scope_id,seen_key,seen_at')
+    .eq('user_id', state.currentUser.id)
+    .in('scope_id', ids);
+
+  if (error) {
+    console.warn('[seen_state] load failed:', error.message);
+    return;
+  }
+  (data || []).forEach(_cacheSeenStateRow);
+}
+
+async function saveSeenState(scopeId, seenKey, seenAt = new Date().toISOString()) {
+  if (!state.currentUser || !navigator.onLine || !scopeId || !seenKey) return;
+  const row = {
+    user_id: state.currentUser.id,
+    scope_id: String(scopeId),
+    seen_key: String(seenKey),
+    seen_at: seenAt,
+    updated_at: new Date().toISOString(),
+  };
+  const { error } = await sb
+    .from('user_seen_state')
+    .upsert(row, { onConflict: 'user_id,scope_id,seen_key' });
+  if (error) throw new Error(error.message);
+}
+
+/* ----------------------------------------------------------
    Home data
    ---------------------------------------------------------- */
 
@@ -68,6 +116,7 @@ async function loadHomeData() {
     (profs || []).forEach(p => { state.profileCache[p.id] = p.username; });
   }
 
+  await loadSeenStates([...state.myTourIds]);
   await computeHomeBadges();
   state._loadedHomeForCid = cid;
 }
@@ -80,6 +129,7 @@ async function computeHomeBadges() {
   state.homeBadges = {};
   const myTourIds = [...state.myTourIds];
   if (!myTourIds.length) return;
+  await loadSeenStates(myTourIds);
 
   // For each tour, find events newer than last-seen timestamp
   await Promise.all(myTourIds.map(async tourId => {
@@ -163,6 +213,7 @@ async function loadTourData(tourId) {
     state.tourCalMonth = new Date(state.currentTour.date + 'T12:00:00');
   }
 
+  await loadSeenStates([tourId]);
   computeTabBadges(tourId);
 }
 
@@ -1142,6 +1193,7 @@ async function computePlanningBadges() {
   if (!cid) return;
   // HEAD requests can't be cached → skip when offline, keep last known counts
   if (!navigator.onLine) return;
+  await loadSeenStates([cid]);
 
   const seenChat  = getLastSeen(cid, 'plan-chat');
   const seenPolls = getLastSeen(cid, 'plan-polls');
@@ -1342,6 +1394,7 @@ async function computeMediaBadges() {
   if (!cid) return;
   // HEAD requests can't be cached → skip when offline, keep last known counts
   if (!navigator.onLine) return;
+  await loadSeenStates([cid]);
   const seenCm = getLastSeen(cid, 'community-media');
   const seenTm = getLastSeen(cid, 'tour-media');
 
@@ -1370,6 +1423,7 @@ async function computeTourMediaCounts() {
   if (!navigator.onLine && state._loadedTourMediaCountsCid === state.currentCommunityId) {
     return;
   }
+  await loadSeenStates([state.currentCommunityId]);
 
   const seenMedia = getLastSeen(state.currentCommunityId, 'tour-media');
 

--- a/js/app.js
+++ b/js/app.js
@@ -397,6 +397,9 @@ function startForegroundRefresh() {
    Render dispatcher
    ---------------------------------------------------------- */
 
+let _renderGeneration = 0;
+let _siteChangelogPopupTimer = null;
+
 /**
  * Re-render the entire #app element based on state.view.
  * After injecting HTML, wire up event listeners.
@@ -404,6 +407,7 @@ function startForegroundRefresh() {
 function render() {
   const app = document.getElementById('app');
   if (!app) return;
+  const renderGeneration = ++_renderGeneration;
 
   const showNav = !['auth', 'loading', 'forgot-password', 'reset-password'].includes(state.view);
 
@@ -425,10 +429,19 @@ function render() {
       default: html += '<div class="loading-screen">…</div>';
     }
 
+    // A full app render replaces modal DOM. If a modal was open during a
+    // background/SWR re-render, clear its scroll lock so the page remains usable.
+    document.body.style.overflow = '';
     app.innerHTML = html;
     attachEvents();
     syncStickyLayout();
     requestAnimationFrame(fitTourCardAvatars);
+    if (typeof maybeOpenSiteChangelogPopup === 'function') {
+      if (_siteChangelogPopupTimer) clearTimeout(_siteChangelogPopupTimer);
+      _siteChangelogPopupTimer = setTimeout(() => {
+        if (renderGeneration === _renderGeneration) maybeOpenSiteChangelogPopup();
+      }, 1800);
+    }
   } catch (e) {
     console.error('[render] error:', e);
     app.innerHTML = `<div style="padding:40px;color:#e04444;font-family:monospace">
@@ -439,6 +452,572 @@ function render() {
 }
 
 window._setTourFilter = (f) => { state.tourFilter = f; render(); };
+
+/* ----------------------------------------------------------
+   Tour weather tab (Open-Meteo, per-user location choice)
+   ---------------------------------------------------------- */
+
+function _weatherChoiceKey(tourId) {
+  return `mr_weather_location_${tourId}`;
+}
+
+function getStoredWeatherChoice(tourId) {
+  try { return localStorage.getItem(_weatherChoiceKey(tourId)); }
+  catch(e) { return null; }
+}
+
+function setStoredWeatherChoice(tourId, value) {
+  try { localStorage.setItem(_weatherChoiceKey(tourId), value); }
+  catch(e) {}
+}
+
+function getTourWeatherOptions(tour = state.currentTour) {
+  const options = [];
+  const meeting = (state.tourPlanDates || []).find(pd => pd.type === 'treffpunkt' && pd.maps_link);
+  if (meeting) {
+    const place = (meeting.label || '').trim();
+    options.push({
+      value: 'meeting',
+      label: place ? `Treffpunkt - ${place}` : 'Treffpunkt',
+      source: place ? `Treffpunkt - ${place}` : 'Treffpunkt',
+      detail: meeting.label || meeting.date || '',
+      mapsLink: meeting.maps_link,
+    });
+  }
+
+  const gpx = normalizeGPXRoute(tour?.gpx_route);
+  (gpx?.tracks || []).forEach((track, trackIndex) => {
+    const points = (track.points || []).filter(p => Number.isFinite(p?.[0]) && Number.isFinite(p?.[1]));
+    if (!points.length) return;
+    const trackName = track.name || `Track ${trackIndex + 1}`;
+    [
+      ['start', 'Anfang', 0],
+      ['middle', 'Mitte', 0.5],
+      ['end', 'Ende', 1],
+    ].forEach(([pos, label, fraction]) => {
+      options.push({
+        value: `track:${trackIndex}:${pos}`,
+        label: `${trackName} ${label}`,
+        source: `${trackName} ${label}`,
+        detail: trackName,
+        trackIndex,
+        fraction,
+      });
+    });
+  });
+
+  return options;
+}
+
+function getSelectedWeatherChoice(tour = state.currentTour) {
+  const options = getTourWeatherOptions(tour);
+  if (!options.length) return null;
+  const stored = getStoredWeatherChoice(tour.id);
+  return options.find(o => o.value === stored) || options[0];
+}
+
+function _trackPointAtFraction(points, fraction) {
+  if (!points?.length) return null;
+  if (fraction <= 0 || points.length === 1) return points[0];
+  if (fraction >= 1) return points[points.length - 1];
+
+  const distances = [];
+  let total = 0;
+  for (let i = 1; i < points.length; i++) {
+    const d = _haversine(points[i - 1], points[i]);
+    distances.push(d);
+    total += d;
+  }
+  if (!total) return points[Math.floor(points.length * fraction)] || points[0];
+
+  const target = total * fraction;
+  let walked = 0;
+  for (let i = 1; i < points.length; i++) {
+    const segment = distances[i - 1];
+    if (walked + segment >= target) {
+      const ratio = segment ? (target - walked) / segment : 0;
+      const a = points[i - 1];
+      const b = points[i];
+      return [
+        a[0] + (b[0] - a[0]) * ratio,
+        a[1] + (b[1] - a[1]) * ratio,
+      ];
+    }
+    walked += segment;
+  }
+  return points[points.length - 1];
+}
+
+async function resolveTourWeatherChoice(choice, tour = state.currentTour) {
+  if (!choice || !tour) return null;
+  if (choice.value === 'meeting') {
+    const coords = await _extractMapCoords(choice.mapsLink);
+    return coords ? { ...coords, label: choice.label, source: choice.source } : null;
+  }
+
+  const match = choice.value.match(/^track:(\d+):(start|middle|end)$/);
+  if (!match) return null;
+  const trackIndex = Number(match[1]);
+  const gpx = normalizeGPXRoute(tour.gpx_route);
+  const points = (gpx?.tracks?.[trackIndex]?.points || []).filter(p => Number.isFinite(p?.[0]) && Number.isFinite(p?.[1]));
+  const point = _trackPointAtFraction(points, choice.fraction);
+  return point ? {
+    latitude: point[0],
+    longitude: point[1],
+    label: choice.label,
+    source: choice.source,
+  } : null;
+}
+
+async function loadTourWeatherTab() {
+  const tour = state.currentTour;
+  const root = document.getElementById('tour-weather-body');
+  if (!tour || !root) return;
+
+  const choices = getTourWeatherOptions(tour);
+  const choice = getSelectedWeatherChoice(tour);
+  if (!choices.length || !choice) {
+    root.innerHTML = '<div class="weather-empty">Keine Wetterposition verfügbar. Lege einen Treffpunkt mit Maps-Link an oder lade eine GPX-Route hoch.</div>';
+    return;
+  }
+
+  root.innerHTML = '<div class="weather-loading">Wetter wird geladen…</div>';
+  try {
+    const resolved = await resolveTourWeatherChoice(choice, tour);
+    if (!resolved) {
+      root.innerHTML = '<div class="weather-empty">Position konnte nicht bestimmt werden.</div>';
+      return;
+    }
+
+    const startDate = tour.date;
+    const endDate = tour.end_date || tour.date;
+    const maxDate = new Date();
+    maxDate.setDate(maxDate.getDate() + 15);
+    const maxDateStr = maxDate.toISOString().slice(0, 10);
+    const clampedEnd = endDate > maxDateStr ? maxDateStr : endDate;
+
+    const resp = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${resolved.latitude}&longitude=${resolved.longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min&hourly=precipitation,precipitation_probability&timezone=auto&start_date=${startDate}&end_date=${clampedEnd}`,
+      { cache: 'no-store' }
+    );
+    const [data, wetnessRows] = await Promise.all([
+      resp.json(),
+      loadAllOffroadWetness(choices, tour),
+    ]);
+    const daily = data.daily || {};
+    const segmentsByDay = _weatherSegmentsByDay(data.hourly);
+    const forecastRows = _renderWeatherForecastRows(daily, segmentsByDay);
+    const coords = `${resolved.latitude.toFixed(5)}, ${resolved.longitude.toFixed(5)}`;
+
+    root.innerHTML = `
+      ${renderOffroadWetnessList(wetnessRows)}
+      <div class="tour-weather-location">
+        <span>${esc(resolved.source || choice.label)}</span>
+        <span>${coords}</span>
+      </div>
+      <div class="tour-weather-grid">${forecastRows || '<div class="weather-empty">Keine Vorhersage für diesen Zeitraum verfügbar.</div>'}</div>
+      ${endDate > maxDateStr ? '<div class="checkin-weather-hint">Vorhersage max. 16 Tage im Voraus verfügbar</div>' : ''}`;
+  } catch (e) {
+    console.warn('[tour weather]', e);
+    root.innerHTML = '<div class="weather-empty">Wetter konnte nicht geladen werden.</div>';
+  }
+}
+
+async function loadOverviewWeatherCard() {
+  const tour = state.currentTour;
+  const el = document.getElementById(`tov-weather-${tour?.id}`);
+  if (!tour || !el) return;
+
+  const choice = getSelectedWeatherChoice(tour);
+  if (!choice) {
+    el.innerHTML = '<div class="tov-empty-hint">Kein Wetterpunkt verfügbar</div>';
+    return;
+  }
+
+  try {
+    const resolved = await resolveTourWeatherChoice(choice, tour);
+    if (!resolved) {
+      el.innerHTML = '<div class="tov-empty-hint">Position nicht verfügbar</div>';
+      return;
+    }
+
+    const endDate = tour.end_date || tour.date;
+    const maxDate = new Date();
+    maxDate.setDate(maxDate.getDate() + 15);
+    const maxDateStr = maxDate.toISOString().slice(0, 10);
+    if (tour.date > maxDateStr) {
+      el.innerHTML = renderOverviewWeatherNA(
+        resolved.source || choice.label,
+        'Vorhersage max. 16 Tage im Voraus verfügbar'
+      );
+      return;
+    }
+
+    const clampedEnd = endDate > maxDateStr ? maxDateStr : endDate;
+    const resp = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${resolved.latitude}&longitude=${resolved.longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min,precipitation_probability_max,precipitation_sum&timezone=auto&start_date=${tour.date}&end_date=${clampedEnd}`,
+      { cache: 'no-store' }
+    );
+    const [data, wetness] = await Promise.all([
+      resp.json(),
+      loadOffroadWetness(resolved.latitude, resolved.longitude),
+    ]);
+
+    const daily = data.daily || {};
+    const idx = 0;
+    const hasForecast = daily.time?.[idx]
+      && Number.isFinite(Number(daily.temperature_2m_max?.[idx]))
+      && Number.isFinite(Number(daily.temperature_2m_min?.[idx]));
+    if (!hasForecast) {
+      el.innerHTML = renderOverviewWeatherNA(
+        resolved.source || choice.label,
+        'Keine Vorhersagedaten für diesen Zeitraum verfügbar'
+      );
+      return;
+    }
+
+    const icon = _weatherIcon(daily.weathercode?.[idx]);
+    const max = Math.round(Number(daily.temperature_2m_max[idx]));
+    const min = Math.round(Number(daily.temperature_2m_min[idx]));
+    const probRaw = Number(daily.precipitation_probability_max?.[idx]);
+    const rainRaw = Number(daily.precipitation_sum?.[idx]);
+    const prob = Number.isFinite(probRaw) ? Math.round(probRaw) : 'N/A';
+    const rain = Number.isFinite(rainRaw)
+      ? rainRaw.toLocaleString('de-DE', { maximumFractionDigits: 1 }) + 'mm'
+      : 'N/A';
+    const wetTotal = wetness.total.toLocaleString('de-DE', { maximumFractionDigits: 1 });
+    const wetMax = wetness.maxHour.toLocaleString('de-DE', { maximumFractionDigits: 1 });
+
+    el.innerHTML = `
+      <div class="tov-weather-location">${esc(resolved.source || choice.label)}</div>
+      <div class="tov-weather-main">
+        <span class="tov-weather-icon">${icon}</span>
+        <span class="tov-weather-temp">${min}° / ${max}°</span>
+      </div>
+      <div class="tov-weather-rain">🌧 ${prob}${prob === 'N/A' ? '' : '%'} · ${rain}</div>
+      <div class="tov-weather-index offroad-wetness-${wetness.level}">
+        <strong>${wetness.label}</strong>
+        <span>48h ${wetTotal}mm · max/h ${wetMax}mm/h</span>
+      </div>`;
+  } catch (e) {
+    console.warn('[overview weather]', e);
+    el.innerHTML = '<div class="tov-empty-hint">Wetter nicht verfügbar</div>';
+  }
+}
+
+function renderOverviewWeatherNA(location, hint) {
+  return `
+    <div class="tov-weather-location">${esc(location || 'Wetterpunkt')}</div>
+    <div class="tov-weather-na">N/A</div>
+    <div class="tov-weather-na-hint">${esc(hint || 'Wetterdaten nicht verfügbar')}</div>`;
+}
+
+function _renderWeatherForecastRows(daily = {}, segmentsByDay = {}) {
+  return (daily.time || []).map((date, idx) => {
+    const dt = new Date(`${date}T12:00:00`);
+    const label = dt.toLocaleDateString('de-DE', { weekday: 'short', day: '2-digit', month: '2-digit' });
+    const icon = _weatherIcon(daily.weathercode?.[idx]);
+    const max = Math.round(daily.temperature_2m_max?.[idx] ?? 0);
+    const min = Math.round(daily.temperature_2m_min?.[idx] ?? 0);
+    const segments = segmentsByDay[date] || _emptyWeatherSegments();
+    const segmentRows = segments.map(s => {
+      const rain = Number(s.precip || 0).toLocaleString('de-DE', { maximumFractionDigits: 1 });
+      return `<div class="tour-weather-segment">
+        <span>${s.label}</span>
+        <span>🌧 ${Math.round(s.prob || 0)}%</span>
+        <span>${rain}mm/h</span>
+      </div>`;
+    }).join('');
+    return `
+      <div class="tour-weather-day">
+        <div class="tour-weather-date">${label}</div>
+        <div class="tour-weather-icon">${icon}</div>
+        <div class="tour-weather-temp">${min}° / ${max}°</div>
+        <div class="tour-weather-segments">${segmentRows}</div>
+      </div>`;
+  }).join('');
+}
+
+function _weatherIcon(code) {
+  if (code === 0) return '☀️';
+  if (code <= 2) return '⛅';
+  if (code <= 3) return '☁️';
+  if (code <= 48) return '🌫️';
+  if (code <= 67) return '🌧️';
+  if (code <= 77) return '❄️';
+  if (code <= 82) return '🌧️';
+  if (code <= 86) return '❄️';
+  return '⚡';
+}
+
+function _emptyWeatherSegments() {
+  return [
+    { key: 'morning', label: 'VM', prob: 0, precip: 0 },
+    { key: 'midday',  label: 'MI', prob: 0, precip: 0 },
+    { key: 'evening', label: 'AB', prob: 0, precip: 0 },
+  ];
+}
+
+function _weatherSegmentsByDay(hourly = {}) {
+  const result = {};
+  (hourly.time || []).forEach((time, idx) => {
+    const day = String(time).slice(0, 10);
+    const hour = Number(String(time).slice(11, 13));
+    const segmentIndex = hour >= 6 && hour < 12 ? 0
+      : hour >= 12 && hour < 18 ? 1
+      : hour >= 18 && hour < 24 ? 2
+      : -1;
+    if (segmentIndex < 0) return;
+    if (!result[day]) result[day] = _emptyWeatherSegments();
+    const segment = result[day][segmentIndex];
+    segment.prob = Math.max(segment.prob, Number(hourly.precipitation_probability?.[idx] || 0));
+    segment.precip = Math.max(segment.precip, Number(hourly.precipitation?.[idx] || 0));
+  });
+  return result;
+}
+
+async function loadOffroadWetness(latitude, longitude) {
+  const resp = await fetch(
+    `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=precipitation&past_hours=48&forecast_hours=1&timezone=auto`,
+    { cache: 'no-store' }
+  );
+  const data = await resp.json();
+  const values = (data.hourly?.precipitation || []).map(v => Number(v || 0));
+  const total = values.reduce((sum, v) => sum + v, 0);
+  const maxHour = values.reduce((max, v) => Math.max(max, v), 0);
+
+  let level = 'dry';
+  let label = 'trocken';
+  if (total >= 25 || maxHour >= 8) {
+    level = 'heavy';
+    label = 'sehr nass';
+  } else if (total >= 10 || maxHour >= 4) {
+    level = 'wet';
+    label = 'nass';
+  } else if (total >= 2 || maxHour >= 1) {
+    level = 'damp';
+    label = 'feucht';
+  }
+
+  return { total, maxHour, level, label };
+}
+
+async function loadAllOffroadWetness(choices, tour) {
+  return Promise.all(choices.map(async choice => {
+    const resolved = await resolveTourWeatherChoice(choice, tour);
+    if (!resolved) return { choice, resolved: null, wetness: null };
+    const wetness = await loadOffroadWetness(resolved.latitude, resolved.longitude);
+    return { choice, resolved, wetness };
+  }));
+}
+
+function renderOffroadWetnessList(rows) {
+  if (!rows?.length) return '';
+  const cells = rows.map(row => {
+    if (!row.wetness) {
+      return {
+        className: 'offroad-wetness-missing',
+        name: row.choice.label,
+        score: '—',
+        total: null,
+        maxHour: null,
+      };
+    }
+    const total = row.wetness.total.toLocaleString('de-DE', { maximumFractionDigits: 1 });
+    const maxHour = row.wetness.maxHour.toLocaleString('de-DE', { maximumFractionDigits: 1 });
+    return {
+      className: `offroad-wetness-${row.wetness.level}`,
+      name: row.resolved.source || row.choice.label,
+      score: row.wetness.label,
+      total,
+      maxHour,
+    };
+  });
+
+  return `<div class="offroad-wetness-matrix-wrap">
+    <div class="offroad-wetness-matrix-title">OffRoad Regen-Index</div>
+    <table class="offroad-wetness-matrix">
+      <tbody>
+        <tr class="offroad-wetness-matrix-names">
+          ${cells.map(c => `<td class="${c.className}">${esc(c.name)}</td>`).join('')}
+        </tr>
+        <tr class="offroad-wetness-matrix-scores">
+          ${cells.map(c => `<td class="${c.className}">${esc(c.score)}</td>`).join('')}
+        </tr>
+        <tr class="offroad-wetness-matrix-history">
+          ${cells.map(c => `<td class="${c.className}">${c.total ? `<span>last 48h:</span><span>ges: ${esc(c.total)} mm</span><span>max/h: ${esc(c.maxHour)} mm/h</span>` : 'Position nicht verfügbar'}</td>`).join('')}
+        </tr>
+      </tbody>
+    </table>
+  </div>`;
+}
+
+function renderOffroadWetness(wetness) {
+  if (!wetness) return '';
+  const total = wetness.total.toLocaleString('de-DE', { maximumFractionDigits: 1 });
+  const maxHour = wetness.maxHour.toLocaleString('de-DE', { maximumFractionDigits: 1 });
+  return `<div class="offroad-wetness offroad-wetness-${wetness.level}">
+    <div>
+      <span class="offroad-wetness-label">Offroad-Nässe</span>
+      <strong>${wetness.label}</strong>
+    </div>
+    <div class="offroad-wetness-meta">
+      <span>48h ${total}mm</span>
+      <span>max st. ${maxHour}mm/h</span>
+    </div>
+  </div>`;
+}
+
+async function openRainRadarModal() {
+  const tour = state.currentTour;
+  const choice = getSelectedWeatherChoice(tour);
+  if (!tour || !choice) {
+    toast('Keine Wetterposition verfügbar.', 'error');
+    return;
+  }
+
+  document.getElementById('rain-radar-overlay')?.remove();
+  const overlay = document.createElement('div');
+  overlay.id = 'rain-radar-overlay';
+  overlay.className = 'rain-radar-overlay';
+  overlay.innerHTML = `
+    <div class="rain-radar-modal">
+      <div class="rain-radar-head">
+        <div>
+          <div class="rain-radar-title">Regenradar</div>
+          <div class="rain-radar-sub" id="rain-radar-sub">Lädt…</div>
+        </div>
+        <button class="rain-radar-close" id="rain-radar-close" aria-label="Schließen">×</button>
+      </div>
+      <div class="rain-radar-map" id="rain-radar-map"></div>
+      <div class="rain-radar-controls">
+        <button class="rain-radar-step" id="rain-radar-prev" title="Zurück">‹</button>
+        <button class="rain-radar-step" id="rain-radar-play" title="Animation starten">▶</button>
+        <input type="range" id="rain-radar-range" min="0" max="0" value="0" />
+        <button class="rain-radar-step" id="rain-radar-next" title="Vor">›</button>
+      </div>
+      <div class="rain-radar-foot">
+        <span id="rain-radar-time"></span>
+        <a href="https://www.rainviewer.com/" target="_blank" rel="noopener">RainViewer</a>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
+  document.body.style.overflow = 'hidden';
+
+  const close = () => {
+    if (window._rainRadarTimer) clearInterval(window._rainRadarTimer);
+    window._rainRadarTimer = null;
+    try { window._rainRadarMap?.remove(); } catch(e) {}
+    window._rainRadarMap = null;
+    overlay.remove();
+    document.body.style.overflow = '';
+  };
+  document.getElementById('rain-radar-close')?.addEventListener('click', close);
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+
+  try {
+    const resolved = await resolveTourWeatherChoice(choice, tour);
+    if (!resolved) throw new Error('Position konnte nicht bestimmt werden.');
+
+    document.getElementById('rain-radar-sub').textContent =
+      `${resolved.source || choice.label} · ${resolved.latitude.toFixed(5)}, ${resolved.longitude.toFixed(5)}`;
+
+    const metaResp = await fetch('https://api.rainviewer.com/public/weather-maps.json', { cache: 'no-store' });
+    const meta = await metaResp.json();
+    const pastFrames = (meta.radar?.past || []).map(f => ({ ...f, kind: 'past' }));
+    const nowcastFrames = (meta.radar?.nowcast || []).map(f => ({ ...f, kind: 'nowcast' }));
+    const frames = [...pastFrames, ...nowcastFrames];
+    if (!meta.host || !frames.length) throw new Error('Keine Radardaten verfügbar.');
+
+    const map = L.map('rain-radar-map', {
+      center: [resolved.latitude, resolved.longitude],
+      zoom: 7,
+      maxZoom: 7,
+      minZoom: 3,
+    });
+    window._rainRadarMap = map;
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      opacity: 0.9,
+      attribution: '&copy; OpenStreetMap',
+    }).addTo(map);
+
+    const boundsPoints = [[resolved.latitude, resolved.longitude]];
+    const gpxData = normalizeGPXRoute(tour.gpx_route);
+    (gpxData?.tracks || []).forEach((track, idx) => {
+      const pts = (track.points || []).filter(p => Number.isFinite(p?.[0]) && Number.isFinite(p?.[1]));
+      if (!pts.length) return;
+      L.polyline(pts.map(p => [p[0], p[1]]), {
+        color: track.color || TRACK_COLORS[idx % TRACK_COLORS.length],
+        weight: 4,
+        opacity: 0.95,
+      }).addTo(map);
+      boundsPoints.push(...pts.map(p => [p[0], p[1]]));
+    });
+
+    L.marker([resolved.latitude, resolved.longitude]).addTo(map);
+
+    const range = document.getElementById('rain-radar-range');
+    const prevBtn = document.getElementById('rain-radar-prev');
+    const nextBtn = document.getElementById('rain-radar-next');
+    const playBtn = document.getElementById('rain-radar-play');
+    let frameIndex = Math.max(0, pastFrames.length - 1);
+    let radarLayer = null;
+
+    range.max = String(frames.length - 1);
+
+    const setFrame = (index) => {
+      frameIndex = Math.max(0, Math.min(frames.length - 1, index));
+      const frame = frames[frameIndex];
+      if (radarLayer) map.removeLayer(radarLayer);
+      radarLayer = L.tileLayer(`${meta.host}${frame.path}/256/{z}/{x}/{y}/2/1_1.png`, {
+        tileSize: 256,
+        opacity: 0.72,
+        maxZoom: 7,
+        attribution: 'Radar: RainViewer',
+      }).addTo(map);
+
+      range.value = String(frameIndex);
+      prevBtn.disabled = frameIndex === 0;
+      nextBtn.disabled = frameIndex === frames.length - 1;
+      const time = new Date(frame.time * 1000).toLocaleString('de-DE', {
+        day: '2-digit',
+        month: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      const tag = frame.kind === 'nowcast' ? 'Nowcast' : 'Radar';
+      document.getElementById('rain-radar-time').textContent = `${tag} ${time}`;
+    };
+
+    prevBtn.addEventListener('click', () => setFrame(frameIndex - 1));
+    nextBtn.addEventListener('click', () => setFrame(frameIndex + 1));
+    range.addEventListener('input', () => setFrame(Number(range.value)));
+    playBtn.addEventListener('click', () => {
+      if (window._rainRadarTimer) {
+        clearInterval(window._rainRadarTimer);
+        window._rainRadarTimer = null;
+        playBtn.textContent = '▶';
+        return;
+      }
+      playBtn.textContent = '⏸';
+      window._rainRadarTimer = setInterval(() => {
+        setFrame(frameIndex >= frames.length - 1 ? 0 : frameIndex + 1);
+      }, 700);
+    });
+
+    setFrame(frameIndex);
+    if (boundsPoints.length > 1) {
+      map.fitBounds(L.latLngBounds(boundsPoints), { padding: [28, 28], maxZoom: 7 });
+    }
+    setTimeout(() => map.invalidateSize(), 80);
+  } catch (e) {
+    console.warn('[rain radar]', e);
+    document.getElementById('rain-radar-sub').textContent = e.message || 'Radar konnte nicht geladen werden.';
+    document.getElementById('rain-radar-map').innerHTML = '<div class="weather-empty">Regenradar konnte nicht geladen werden.</div>';
+  }
+}
 
 /* ----------------------------------------------------------
    Check-in weather forecast (Open-Meteo, free, no API key)
@@ -475,7 +1054,7 @@ async function _extractMapCoords(url) {
   return null;
 }
 
-async function _loadCheckinWeather(tourId, destination, startDate, endDate, mapsLink) {
+async function _loadCheckinWeather(tourId, destination, startDate, endDate, mapsLink, tour = null) {
   const weatherEl = document.getElementById(`checkin-weather-${tourId}`);
   if (!weatherEl) return;
 
@@ -491,19 +1070,42 @@ async function _loadCheckinWeather(tourId, destination, startDate, endDate, maps
     return '⚡';
   };
 
+  const forecastConfidence = () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const start = new Date(`${startDate}T00:00:00`);
+    const daysUntilStart = Math.round((start - today) / 86400000);
+    if (daysUntilStart <= 3) return { label: 'HOCH', className: 'high' };
+    if (daysUntilStart <= 7) return { label: 'MITTEL', className: 'medium' };
+    return { label: 'NIEDRIG', className: 'low' };
+  };
+
+  const applyConfidence = (hasTruncated) => {
+    const el = document.getElementById(`checkin-weather-confidence-${tourId}`);
+    if (!el) return;
+    const confidence = hasTruncated ? { label: 'NIEDRIG', className: 'low' } : forecastConfidence();
+    el.textContent = `SICHERHEIT ${confidence.label}`;
+    el.className = `checkin-weather-confidence checkin-weather-confidence-${confidence.className}`;
+  };
+
   // Helper: write fetched data into current DOM (called from cache and from fresh fetch)
-  const applyWeather = (days, codes, temps, hasTruncated, maxDateStr) => {
+  const applyWeather = (days, codes, temps, precipProbs, precipSums, hasTruncated, maxDateStr) => {
     const el = document.getElementById(`checkin-weather-${tourId}`);
     if (!el) return;
+    applyConfidence(hasTruncated);
     el.querySelectorAll('.checkin-weather-day').forEach(row => {
       const date = row.dataset.date;
       const idx  = days.indexOf(date);
       if (idx !== -1) {
         row.querySelector('[data-wicon]').textContent = wmoIcon(codes[idx]);
         row.querySelector('[data-wtemp]').textContent = `${Math.round(temps[idx])}°C`;
+        row.querySelector('[data-wrainprob]').textContent = `🌧 ${Math.round(precipProbs[idx] || 0)}%`;
+        row.querySelector('[data-wrain]').textContent = `${Number(precipSums[idx] || 0).toLocaleString('de-DE', { maximumFractionDigits: 1 })}mm`;
       } else if (date > maxDateStr) {
         row.querySelector('[data-wicon]').textContent = '—';
         row.querySelector('[data-wtemp]').textContent = '';
+        row.querySelector('[data-wrainprob]').textContent = '';
+        row.querySelector('[data-wrain]').textContent = '';
         row.style.opacity = '0.4';
       }
     });
@@ -533,7 +1135,7 @@ async function _loadCheckinWeather(tourId, destination, startDate, endDate, maps
   const WEATHER_CACHE_MAX_AGE_MS = 60 * 60 * 1000;
   const now = Date.now();
   const today = new Date(now).toISOString().slice(0, 10);
-  const cacheKey = [destination || '', startDate || '', endDate || '', mapsLink || ''].join('|');
+  const cacheKey = ['v3', destination || '', startDate || '', endDate || '', mapsLink || '', tour?.gpx_route ? 'gpx' : ''].join('|');
   const cached = state.weatherCache[tourId];
   const cachedFetchedAt = cached?.fetchedAt
     || (cached?.fetchDate ? Date.parse(`${cached.fetchDate}T00:00:00`) : 0);
@@ -542,48 +1144,71 @@ async function _loadCheckinWeather(tourId, destination, startDate, endDate, maps
   const isOnline = navigator.onLine !== false;
 
   if (cacheMatches) {
-    applyWeather(cached.days || [], cached.codes || [], cached.temps || [], hasTruncated, maxDateStr);
+    applyWeather(
+      cached.days || [],
+      cached.codes || [],
+      cached.temps || [],
+      cached.precipProbs || [],
+      cached.precipSums || [],
+      hasTruncated,
+      maxDateStr
+    );
     if (hasFreshCache || !isOnline) return;
   }
   if (!isOnline) return;
 
   try {
-    // 1. Resolve coordinates — prefer Treffpunkt maps link, fall back to geocoding
+    // 1. Resolve coordinates — prefer Treffpunkt maps link, then destination, then GPX start
     let latitude, longitude;
     const fromMap = await _extractMapCoords(mapsLink);
     if (fromMap) {
       ({ latitude, longitude } = fromMap);
     } else {
-      if (!destination) return;
-      const geoResp = await fetch(
-        `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(destination)}&count=1&language=de&format=json`
-      );
-      const geoData = await geoResp.json();
-      if (!geoData.results?.length) return;
-      ({ latitude, longitude } = geoData.results[0]);
+      if (destination) {
+        const geoResp = await fetch(
+          `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(destination)}&count=1&language=de&format=json`
+        );
+        const geoData = await geoResp.json();
+        if (geoData.results?.length) ({ latitude, longitude } = geoData.results[0]);
+      }
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+        const gpx = normalizeGPXRoute(tour?.gpx_route);
+        const firstPoint = (gpx?.tracks || [])
+          .flatMap(track => track.points || [])
+          .find(p => Number.isFinite(p?.[0]) && Number.isFinite(p?.[1]));
+        if (firstPoint) {
+          latitude = firstPoint[0];
+          longitude = firstPoint[1];
+        }
+      }
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return;
     }
 
     // 2. Fetch forecast (only if tour start is within forecast window)
     const days  = [];
     const codes = [];
     const temps = [];
+    const precipProbs = [];
+    const precipSums  = [];
     if (startDate <= maxDateStr) {
       const weatherResp = await fetch(
-        `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=temperature_2m_max,weathercode&timezone=auto&start_date=${startDate}&end_date=${clampedEnd}`,
+        `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=temperature_2m_max,weathercode,precipitation_probability_max,precipitation_sum&timezone=auto&start_date=${startDate}&end_date=${clampedEnd}`,
         { cache: 'no-store' }
       );
       const weatherData = await weatherResp.json();
-      days.push(...(weatherData.daily?.time               || []));
-      codes.push(...(weatherData.daily?.weathercode        || []));
-      temps.push(...(weatherData.daily?.temperature_2m_max || []));
+      days.push(...(weatherData.daily?.time                          || []));
+      codes.push(...(weatherData.daily?.weathercode                   || []));
+      temps.push(...(weatherData.daily?.temperature_2m_max            || []));
+      precipProbs.push(...(weatherData.daily?.precipitation_probability_max || []));
+      precipSums.push(...(weatherData.daily?.precipitation_sum        || []));
     }
 
     // 3. Save to cache so SWR second-render reuses without re-fetching
-    state.weatherCache[tourId] = { days, codes, temps, fetchDate: today, fetchedAt: Date.now(), cacheKey };
+    state.weatherCache[tourId] = { days, codes, temps, precipProbs, precipSums, fetchDate: today, fetchedAt: Date.now(), cacheKey };
     if (typeof persistState === 'function') persistState();
 
     // 4. Apply to DOM
-    applyWeather(days, codes, temps, hasTruncated, maxDateStr);
+    applyWeather(days, codes, temps, precipProbs, precipSums, hasTruncated, maxDateStr);
   } catch (e) {
     console.warn('[checkin weather]', e);
   }
@@ -725,6 +1350,7 @@ async function init() {
           defaultCommunityId: profile.default_community_id || null,
         };
         state.profileCache[session.user.id] = profile.username;
+        migrateLegacySeenStateForCurrentUser();
         startHeartbeat();
 
         if (joinId) {

--- a/js/auth.js
+++ b/js/auth.js
@@ -50,6 +50,7 @@ async function doRegister() {
 
     state.currentUser = { id: data.user.id, username };
     state.profileCache[data.user.id] = username;
+    migrateLegacySeenStateForCurrentUser();
     startHeartbeat();
     await navigateTo('communities');
   } catch (e) {
@@ -89,6 +90,7 @@ async function doLogin() {
       defaultCommunityId: profile?.default_community_id || null,
     };
     state.profileCache[data.user.id] = state.currentUser.username;
+    migrateLegacySeenStateForCurrentUser();
     startHeartbeat();
     if (profile?.default_community_id) {
       await navigateTo('community-home', { currentCommunityId: profile.default_community_id });

--- a/js/events.js
+++ b/js/events.js
@@ -614,8 +614,8 @@ function attachEvents() {
     const treffpunktLink = nextTour
       ? (state.tourPlanDates || []).find(pd => pd.type === 'treffpunkt' && pd.maps_link)?.maps_link
       : null;
-    if (nextTour && (nextTour.destination || treffpunktLink)) {
-      _loadCheckinWeather(nextTour.id, nextTour.destination, nextTour.date, nextTour.end_date || nextTour.date, treffpunktLink);
+    if (nextTour && (nextTour.destination || treffpunktLink || nextTour.gpx_route)) {
+      _loadCheckinWeather(nextTour.id, nextTour.destination, nextTour.date, nextTour.end_date || nextTour.date, treffpunktLink, nextTour);
     }
   }
 
@@ -870,6 +870,7 @@ function afterTabRender() {
       });
     });
     setTimeout(() => _initOverviewMap(), 80);
+    setTimeout(() => loadOverviewWeatherCard(), 80);
   }
   if (state.currentTab === 'map') {
     setTimeout(() => {
@@ -898,12 +899,26 @@ function afterTabRender() {
   if (state.currentTab === 'info') {
     attachInfoEvents();
   }
+  if (state.currentTab === 'weather') {
+    attachWeatherTabEvents();
+    loadTourWeatherTab();
+  }
   if (state.currentTab === 'media') {
     attachMediaEvents();
   }
   if (state.currentTab === 'participants') {
     attachParticipantEvents();
   }
+}
+
+function attachWeatherTabEvents() {
+  document.getElementById('tour-weather-location')?.addEventListener('change', e => {
+    setStoredWeatherChoice(state.currentTourId, e.target.value);
+    loadTourWeatherTab();
+  });
+  document.getElementById('tour-weather-radar')?.addEventListener('click', () => {
+    openRainRadarModal();
+  });
 }
 
 /**
@@ -964,6 +979,7 @@ function _refreshTabBar() {
     { id: 'map',          label: 'Karte' },
     { id: 'chat',         label: 'Chat' },
     { id: 'media',        label: 'Media' },
+    { id: 'weather',      label: 'Wetter' },
     { id: 'participants', label: 'Teilnehmer' },
     { id: 'info',         label: 'Info' },
     { id: 'changelog',    label: 'Log' },
@@ -2418,17 +2434,54 @@ function _refreshCommunityMediaMain() {
 let _siteContent = null;     // { info: {key,content,...}, changelog: {...} }
 let _siteCurrentTab = 'info';
 let _siteEditing = false;
+let _siteChangelogAutoCheckDone = false;
+let _siteChangelogAutoCheckRunning = false;
+let _siteChangelogPendingSeenAt = null;
 
-async function openSiteInfoModal() {
+function _isNewerSiteContentUpdate(updatedAt, seenDate) {
+  if (!updatedAt) return false;
+  const updatedMs = new Date(updatedAt).getTime();
+  const seenMs = seenDate instanceof Date ? seenDate.getTime() : 0;
+  return Number.isFinite(updatedMs) && Number.isFinite(seenMs) && updatedMs > seenMs;
+}
+
+async function maybeOpenSiteChangelogPopup() {
+  if (_siteChangelogAutoCheckDone || _siteChangelogAutoCheckRunning) return;
+  if (!state.currentUser || !navigator.onLine) return;
+  if (['auth', 'loading', 'forgot-password', 'reset-password'].includes(state.view)) return;
+  if (document.getElementById('site-info-overlay')?.style.display === 'flex') return;
+  if ((typeof _navigating !== 'undefined' && _navigating)
+    || (typeof _foregroundRefreshRunning !== 'undefined' && _foregroundRefreshRunning)) {
+    return;
+  }
+
+  _siteChangelogAutoCheckRunning = true;
+  _siteChangelogAutoCheckDone = true;
+
+  try {
+    if (typeof loadSeenStates === 'function') await loadSeenStates(['site']);
+    const content = await loadSiteContent();
+    const changelog = content?.changelog;
+    if (!_isNewerSiteContentUpdate(changelog?.updated_at, getLastSeen('site', 'changelog'))) return;
+    await openSiteInfoModal({ initialTab: 'changelog', initialContent: content, markSeenOnClose: true });
+  } catch (e) {
+    console.warn('[site_changelog_popup]', e.message || e);
+  } finally {
+    _siteChangelogAutoCheckRunning = false;
+  }
+}
+
+async function openSiteInfoModal(options = {}) {
   const overlay = document.getElementById('site-info-overlay');
   if (!overlay) return;
+  const initialTab = options.initialTab === 'info' ? 'info' : 'changelog';
   overlay.style.display = 'flex';
   document.body.style.overflow = 'hidden';
 
   // Reset to view mode + changelog tab (most likely what user is looking for)
   _siteEditing = false;
-  _siteCurrentTab = 'changelog';
-  _setSiteInfoTabUI('changelog');
+  _siteCurrentTab = initialTab;
+  _setSiteInfoTabUI(initialTab);
   _setSiteInfoModeUI('view');
 
   // Load (with placeholder while loading)
@@ -2437,13 +2490,20 @@ async function openSiteInfoModal() {
     if (el) el.innerHTML = '<div style="color:var(--muted);padding:20px">Lädt…</div>';
   }
   try {
-    _siteContent = await loadSiteContent();
+    _siteContent = options.initialContent || await loadSiteContent();
   } catch (e) {
     toast('Inhalte konnten nicht geladen werden', 'error');
     _siteContent = {};
   }
   _renderSiteInfoView('info');
   _renderSiteInfoView('changelog');
+  if (_siteContent?.changelog?.updated_at) {
+    if (options.markSeenOnClose) {
+      _siteChangelogPendingSeenAt = _siteContent.changelog.updated_at;
+    } else {
+      markTabSeen('site', 'changelog', _siteContent.changelog.updated_at);
+    }
+  }
 }
 
 function closeSiteInfoModal() {
@@ -2459,6 +2519,10 @@ function closeSiteInfoModal() {
   }
   overlay.style.display = 'none';
   document.body.style.overflow = '';
+  if (_siteChangelogPendingSeenAt) {
+    markTabSeen('site', 'changelog', _siteChangelogPendingSeenAt);
+    _siteChangelogPendingSeenAt = null;
+  }
   _siteEditing = false;
 }
 

--- a/js/render.js
+++ b/js/render.js
@@ -1122,6 +1122,7 @@ function renderTour() {
     { id: 'map',          label: 'Karte' },
     { id: 'chat',         label: 'Chat' },
     { id: 'media',        label: 'Media' },
+    { id: 'weather',      label: 'Wetter' },
     { id: 'participants', label: 'Teilnehmer' },
     { id: 'info',         label: 'Info' },
     { id: 'changelog',    label: 'Log' },
@@ -1169,11 +1170,46 @@ function renderTab(tour) {
     case 'map':          return renderMapTab(tour);
     case 'chat':         return renderChatTab();
     case 'media':        return renderMediaTab();
+    case 'weather':      return renderWeatherTab(tour);
     case 'participants': return renderParticipantsTab();
     case 'info':         return renderInfoTab(tour);
     case 'changelog':    return renderChangelogTab();
     default: return '';
   }
+}
+
+function renderWeatherTab(tour) {
+  const options = typeof getTourWeatherOptions === 'function' ? getTourWeatherOptions(tour) : [];
+  const selected = typeof getSelectedWeatherChoice === 'function' ? getSelectedWeatherChoice(tour) : options[0];
+
+  if (!options.length) {
+    return `<div class="tab-scroll">
+      <div class="tour-weather-layout">
+        <h2>Wetter</h2>
+        <div class="weather-empty">Keine Wetterposition verfügbar. Lege einen Treffpunkt mit Maps-Link an oder lade eine GPX-Route hoch.</div>
+      </div>
+    </div>`;
+  }
+
+  return `<div class="tab-scroll">
+    <div class="tour-weather-layout">
+      <div class="tour-weather-head">
+        <h2>Wetter</h2>
+        <div class="tour-weather-controls">
+          <label class="tour-weather-select-wrap">
+            <span>Wetter für</span>
+            <select id="tour-weather-location">
+              ${options.map(o => `<option value="${esc(o.value)}" ${selected?.value === o.value ? 'selected' : ''}>${esc(o.label)}</option>`).join('')}
+            </select>
+          </label>
+          <button class="btn btn-primary btn-sm" id="tour-weather-radar">Regenradar</button>
+        </div>
+      </div>
+      <div id="tour-weather-body">
+        <div class="weather-loading">Wetter wird geladen…</div>
+      </div>
+    </div>
+  </div>`;
 }
 
 /* ----------------------------------------------------------
@@ -1364,6 +1400,13 @@ function renderTourOverview(tour) {
       }).join('')
     : '<div class="tov-empty-hint">Keine Einträge</div>';
 
+  const weatherChoice = typeof getSelectedWeatherChoice === 'function' ? getSelectedWeatherChoice(tour) : null;
+  const weatherBody = weatherChoice
+    ? `<div class="tov-weather-body" id="tov-weather-${tour.id}">
+         <div class="tov-empty-hint">Wetter wird geladen…</div>
+       </div>`
+    : '<div class="tov-empty-hint">Kein Wetterpunkt verfügbar</div>';
+
   // ── LAYOUT ────────────────────────────────────────────────────────────────
   return `
 <div class="tab-scroll">
@@ -1400,6 +1443,10 @@ function renderTourOverview(tour) {
       <div class="tov-card tov-card-mini" data-go-tab="media">
         <div class="tov-card-eyebrow">MEDIA ${badge('media')}</div>
         ${mediaBody}
+      </div>
+      <div class="tov-card tov-card-mini" data-go-tab="weather">
+        <div class="tov-card-eyebrow">WETTER</div>
+        ${weatherBody}
       </div>
       <div class="tov-card tov-card-mini" data-go-tab="participants">
         <div class="tov-card-eyebrow">TEILNEHMER</div>
@@ -2346,6 +2393,8 @@ function renderCommunityHome() {
         <span class="checkin-wd-label">${label}</span>
         <span class="checkin-wd-icon" data-wicon="${iso}">N/A</span>
         <span class="checkin-wd-temp" data-wtemp="${iso}"></span>
+        <span class="checkin-wd-rainprob" data-wrainprob="${iso}"></span>
+        <span class="checkin-wd-rain" data-wrain="${iso}"></span>
       </div>`;
     }).join('');
 
@@ -2398,6 +2447,7 @@ function renderCommunityHome() {
       <div class="checkin-section">
         <div class="checkin-section-hdr">
           <span class="checkin-section-lbl">WETTERVORHERSAGE</span>
+          <span class="checkin-weather-confidence" id="checkin-weather-confidence-${tourId}">SICHERHEIT —</span>
         </div>
         <div class="checkin-weather-rows" id="checkin-weather-${tourId}">${weatherRows}</div>
       </div>` : ''}

--- a/js/state.js
+++ b/js/state.js
@@ -38,6 +38,7 @@ const state = {
   memberCounts:  {},
   tourMemberIds: {},
   homeBadges:    {},
+  seenState:     {},
   calMonth:      null,       // home calendar current month
   calView:       'month',    // 'month' | 'year' — home calendar
   planCalView:   'year',     // 'month' | 'year' — planning calendar
@@ -102,6 +103,7 @@ function persistState() {
       tourMemberIds:      state.tourMemberIds,
       tourMediaCounts:    state.tourMediaCounts,
       tourMediaNew:       state.tourMediaNew,
+      seenState:          state.seenState,
       weatherCache:       state.weatherCache,
       myTourIds:          [...(state.myTourIds || [])],
       myCommunityIds:     [...(state.myCommunityIds || [])],

--- a/js/utils.js
+++ b/js/utils.js
@@ -188,7 +188,7 @@ function copyPageLink() {
 }
 
 /* ----------------------------------------------------------
-   Tab "last seen" tracking – stored in localStorage
+   "last seen" tracking – Supabase-backed with local fallback
    ---------------------------------------------------------- */
 
 /**
@@ -197,42 +197,143 @@ function copyPageLink() {
  * @param {string} tab
  * @returns {string}
  */
-function _seenKey(tourId, tab) {
-  return `mr_seen_${tourId}_${tab}`;
+function _seenUserId() {
+  return state?.currentUser?.id || 'anon';
 }
 
-/**
- * Mark a tab as seen right now.
- * @param {string} tourId
- * @param {string} tab
- */
-function markTabSeen(tourId, tab) {
-  try { localStorage.setItem(_seenKey(tourId, tab), new Date().toISOString()); } catch(e) {}
+function _seenKey(scopeId, seenKey, userId = _seenUserId()) {
+  return `mr_seen_${userId}_${scopeId}_${seenKey}`;
+}
 
-  // Home-Karten-Badge optimistisch leeren, damit der SWR-Sofort-Render
-  // beim Zurückgehen zur Community-Home keine alte (stale) Markierung mehr zeigt.
-  // computeHomeBadges bestätigt das später nochmal mit frischen Server-Daten.
-  if (typeof state !== 'undefined' && state.homeBadges?.[tourId]) {
-    if (tab === 'chat')      state.homeBadges[tourId].chat      = 0;
-    if (tab === 'changelog') state.homeBadges[tourId].changelog = 0;
-    const b = state.homeBadges[tourId];
-    if ((b.chat || 0) === 0 && (b.changelog || 0) === 0) {
-      delete state.homeBadges[tourId];
+function _seenCacheKey(scopeId, seenKey, userId = _seenUserId()) {
+  return `${userId || 'anon'}\u0001${scopeId || ''}\u0001${seenKey || ''}`;
+}
+
+function _legacySeenKey(scopeId, seenKey) {
+  return `mr_seen_${scopeId}_${seenKey}`;
+}
+
+const LEGACY_SEEN_OWNER_KEY = 'mr_seen_legacy_owner_v1';
+const LEGACY_SEEN_KEYS = [
+  'community-media',
+  'tour-media',
+  'plan-chat',
+  'plan-polls',
+  'changelog',
+  'chat',
+  'info',
+  'media',
+];
+
+function _parseLegacySeenStorageKey(storageKey) {
+  if (!storageKey?.startsWith('mr_seen_')) return null;
+  const rest = storageKey.slice('mr_seen_'.length);
+  for (const seenKey of LEGACY_SEEN_KEYS) {
+    const suffix = `_${seenKey}`;
+    if (!rest.endsWith(suffix)) continue;
+    const scopeId = rest.slice(0, -suffix.length);
+    if (!scopeId || scopeId === _seenUserId()) return null;
+    return { scopeId, seenKey };
+  }
+  return null;
+}
+
+function migrateLegacySeenStateForCurrentUser() {
+  const userId = _seenUserId();
+  if (!userId || userId === 'anon') return;
+
+  let owner = null;
+  try { owner = localStorage.getItem(LEGACY_SEEN_OWNER_KEY); } catch(e) {}
+  if (!owner) {
+    try {
+      const hasLegacyKeys = Object.keys(localStorage).some(k => !!_parseLegacySeenStorageKey(k));
+      if (!hasLegacyKeys) return;
+      localStorage.setItem(LEGACY_SEEN_OWNER_KEY, userId);
+      owner = userId;
+    } catch(e) { return; }
+  }
+  if (owner !== userId) return;
+
+  for (const storageKey of Object.keys(localStorage)) {
+    const parsed = _parseLegacySeenStorageKey(storageKey);
+    if (!parsed) continue;
+    let seenAt = '';
+    try { seenAt = localStorage.getItem(storageKey) || ''; } catch(e) {}
+    if (!Number.isFinite(new Date(seenAt).getTime())) continue;
+
+    const userKey = _seenKey(parsed.scopeId, parsed.seenKey, userId);
+    try {
+      if (!localStorage.getItem(userKey)) localStorage.setItem(userKey, seenAt);
+    } catch(e) {}
+
+    if (!state.seenState) state.seenState = {};
+    const cacheKey = _seenCacheKey(parsed.scopeId, parsed.seenKey, userId);
+    if (!state.seenState[cacheKey]) state.seenState[cacheKey] = seenAt;
+
+    if (typeof saveSeenState === 'function') {
+      saveSeenState(parsed.scopeId, parsed.seenKey, seenAt).catch(e => {
+        console.warn('[seen_state] legacy migration failed:', e.message || e);
+      });
     }
   }
 }
 
 /**
- * Get the Date the user last visited a tab (or epoch if never).
- * @param {string} tourId
- * @param {string} tab
+ * Mark a badge/banner scope as seen right now.
+ * Writes locally immediately and syncs to Supabase in the background.
+ * @param {string} scopeId
+ * @param {string} seenKey
+ * @param {string} [seenAt]
+ */
+function markTabSeen(scopeId, seenKey, seenAt = new Date().toISOString()) {
+  try { localStorage.setItem(_seenKey(scopeId, seenKey), seenAt); } catch(e) {}
+
+  if (typeof state !== 'undefined') {
+    if (!state.seenState) state.seenState = {};
+    state.seenState[_seenCacheKey(scopeId, seenKey)] = seenAt;
+  }
+
+  if (typeof saveSeenState === 'function') {
+    saveSeenState(scopeId, seenKey, seenAt).catch(e => {
+      console.warn('[seen_state] save failed:', e.message || e);
+    });
+  }
+
+  // Home-Karten-Badge optimistisch leeren, damit der SWR-Sofort-Render
+  // beim Zurückgehen zur Community-Home keine alte (stale) Markierung mehr zeigt.
+  // computeHomeBadges bestätigt das später nochmal mit frischen Server-Daten.
+  if (typeof state !== 'undefined' && state.homeBadges?.[scopeId]) {
+    if (seenKey === 'chat')      state.homeBadges[scopeId].chat      = 0;
+    if (seenKey === 'changelog') state.homeBadges[scopeId].changelog = 0;
+    const b = state.homeBadges[scopeId];
+    if ((b.chat || 0) === 0 && (b.changelog || 0) === 0) {
+      delete state.homeBadges[scopeId];
+    }
+  }
+}
+
+/**
+ * Get the Date the user last saw a badge/banner scope (or epoch if never).
+ * Supabase-loaded values win over localStorage so seen-state follows the user
+ * across devices after loadSeenStates() has populated the cache.
+ * @param {string} scopeId
+ * @param {string} seenKey
  * @returns {Date}
  */
-function getLastSeen(tourId, tab) {
+function getLastSeen(scopeId, seenKey) {
+  const values = [];
+  const cached = state?.seenState?.[_seenCacheKey(scopeId, seenKey)];
+  if (cached) values.push(cached);
   try {
-    const v = localStorage.getItem(_seenKey(tourId, tab));
-    return v ? new Date(v) : new Date(0);
-  } catch(e) { return new Date(0); }
+    const local = localStorage.getItem(_seenKey(scopeId, seenKey));
+    if (local) values.push(local);
+  } catch(e) {}
+
+  const newest = values
+    .map(v => new Date(v))
+    .filter(d => Number.isFinite(d.getTime()))
+    .sort((a, b) => b - a)[0];
+  return newest || new Date(0);
 }
 
 /**

--- a/supabase/migrations/20260427140707_remote_history_placeholder.sql
+++ b/supabase/migrations/20260427140707_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260427210205_remote_history_placeholder.sql
+++ b/supabase/migrations/20260427210205_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260428202243_remote_history_placeholder.sql
+++ b/supabase/migrations/20260428202243_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260428212226_remote_history_placeholder.sql
+++ b/supabase/migrations/20260428212226_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260429075915_remote_history_placeholder.sql
+++ b/supabase/migrations/20260429075915_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260429214639_remote_history_placeholder.sql
+++ b/supabase/migrations/20260429214639_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260430185657_remote_history_placeholder.sql
+++ b/supabase/migrations/20260430185657_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260430191519_remote_history_placeholder.sql
+++ b/supabase/migrations/20260430191519_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260430191937_remote_history_placeholder.sql
+++ b/supabase/migrations/20260430191937_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260506162345_remote_history_placeholder.sql
+++ b/supabase/migrations/20260506162345_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260506164900_remote_history_placeholder.sql
+++ b/supabase/migrations/20260506164900_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260508120600_user_seen_state.sql
+++ b/supabase/migrations/20260508120600_user_seen_state.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+--  user_seen_state.sql
+--  Per-user "seen" markers for badges, banners and site changelog
+-- ============================================================
+
+create table if not exists public.user_seen_state (
+  user_id   uuid references auth.users(id) on delete cascade not null,
+  scope_id  text not null,       -- tour id, community id, or 'site'
+  seen_key  text not null,       -- chat, changelog, info, media, plan-chat, ...
+  seen_at   timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, scope_id, seen_key)
+);
+
+alter table public.user_seen_state enable row level security;
+
+drop policy if exists "User kann eigene seen marker lesen" on public.user_seen_state;
+create policy "User kann eigene seen marker lesen"
+  on public.user_seen_state for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+drop policy if exists "User kann eigene seen marker setzen" on public.user_seen_state;
+create policy "User kann eigene seen marker setzen"
+  on public.user_seen_state for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+drop policy if exists "User kann eigene seen marker aktualisieren" on public.user_seen_state;
+create policy "User kann eigene seen marker aktualisieren"
+  on public.user_seen_state for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create index if not exists idx_user_seen_state_scope
+  on public.user_seen_state (user_id, scope_id);


### PR DESCRIPTION
## Summary
- add a Tour weather tab with selectable forecast points, segmented precipitation, RainViewer radar, route overlays, and OffRoad Regen-Index
- add the weather summary card to the tour overview and improve check-in weather details
- store seen-state for badges, banners, and site changelog per user in Supabase with local legacy migration
- reduce duplicate changelog entries for route, offroad analysis, and participant actions

## Validation
- node --check js/app.js
- node --check js/api.js
- node --check js/auth.js
- node --check js/events.js
- node --check js/render.js
- node --check js/state.js
- node --check js/utils.js
- supabase db push applied migration 20260508120600_user_seen_state.sql
- supabase db push --dry-run reports remote database is up to date