### PR TITLE
Harden persisted state restore

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -36,7 +36,7 @@ function _cacheSeenStateRow(row) {
 }
 
 function _seenLoadCacheKey(ids) {
-  return ids.slice().sort().join('\u0001');
+  return `${state.currentUser?.id || 'anon'}\u0002${ids.slice().sort().join('\u0001')}`;
 }
 
 const SEEN_STATE_CACHE_MS = 15 * 1000;

--- a/js/app.js
+++ b/js/app.js
@@ -1328,10 +1328,24 @@ async function init() {
     }
 
     if (session) {
+      if (restoredAtBoot && state.currentUser?.id && state.currentUser.id !== session.user.id) {
+        clearPersistedState();
+        state.currentCommunityId = null;
+        state.currentCommunity = null;
+        state.currentTourId = null;
+        state.currentTour = null;
+        state.tours = [];
+        state.myTourIds = new Set();
+        state.communityPolls = [];
+        state.communityMessages = [];
+        state.communityChangelog = [];
+        state.seenState = {};
+      }
+
       // Vor dem Profile-Fetch: gespeicherten State opportunistisch laden,
       // damit SWR-Fast-Path greifen kann (sofortiges Render mit alten Daten,
       // dann stille Aktualisierung im Hintergrund)
-      if (!restoredAtBoot) restoreState();
+      if (!restoredAtBoot) restoreState(session.user.id);
 
       const { data: profile } = await _withTimeout(
         sb
@@ -1350,7 +1364,7 @@ async function init() {
           defaultCommunityId: profile.default_community_id || null,
         };
         state.profileCache[session.user.id] = profile.username;
-        migrateLegacySeenStateForCurrentUser();
+        await migrateLegacySeenStateForCurrentUser();
         startHeartbeat();
 
         if (joinId) {

--- a/js/auth.js
+++ b/js/auth.js
@@ -50,7 +50,7 @@ async function doRegister() {
 
     state.currentUser = { id: data.user.id, username };
     state.profileCache[data.user.id] = username;
-    migrateLegacySeenStateForCurrentUser();
+    await migrateLegacySeenStateForCurrentUser();
     startHeartbeat();
     await navigateTo('communities');
   } catch (e) {
@@ -90,7 +90,7 @@ async function doLogin() {
       defaultCommunityId: profile?.default_community_id || null,
     };
     state.profileCache[data.user.id] = state.currentUser.username;
-    migrateLegacySeenStateForCurrentUser();
+    await migrateLegacySeenStateForCurrentUser();
     startHeartbeat();
     if (profile?.default_community_id) {
       await navigateTo('community-home', { currentCommunityId: profile.default_community_id });

--- a/js/state.js
+++ b/js/state.js
@@ -77,6 +77,7 @@ const state = {
    offline with previously cached data.
    ---------------------------------------------------------- */
 const STATE_STORAGE_KEY = 'motoroute_state_v1';
+const STATE_SCHEMA_VERSION = 2;
 const STATE_MAX_AGE_MS  = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 function persistState() {
@@ -84,6 +85,7 @@ function persistState() {
   try {
     // Convert Sets and other non-serializable values to plain types
     const snap = {
+      schemaVersion: STATE_SCHEMA_VERSION,
       ts: Date.now(),
       currentUser:        state.currentUser,
       currentCommunityId: state.currentCommunityId,
@@ -123,12 +125,20 @@ function persistState() {
   }
 }
 
-function restoreState() {
+function restoreState(expectedUserId) {
   try {
     const raw = localStorage.getItem(STATE_STORAGE_KEY);
     if (!raw) return false;
     const snap = JSON.parse(raw);
     if (!snap || !snap.ts) return false;
+    if (snap.schemaVersion !== STATE_SCHEMA_VERSION) {
+      localStorage.removeItem(STATE_STORAGE_KEY);
+      return false;
+    }
+    if (expectedUserId && snap.currentUser?.id !== expectedUserId) {
+      localStorage.removeItem(STATE_STORAGE_KEY);
+      return false;
+    }
     if (Date.now() - snap.ts > STATE_MAX_AGE_MS) {
       localStorage.removeItem(STATE_STORAGE_KEY);
       return false;
@@ -142,6 +152,7 @@ function restoreState() {
       Object.entries(snap.tourCheckins || {}).map(([k, v]) => [k, new Set(v || [])])
     );
     delete state.ts;
+    delete state.schemaVersion;
     return true;
   } catch (e) {
     console.warn('[restoreState]', e);

--- a/js/utils.js
+++ b/js/utils.js
@@ -218,7 +218,7 @@ function _legacySeenKey(scopeId, seenKey) {
 }
 
 const LEGACY_SEEN_OWNER_KEY = 'mr_seen_legacy_owner_v1';
-const LEGACY_SEEN_MIGRATED_PREFIX = 'mr_seen_legacy_migrated_v1_';
+const LEGACY_SEEN_MIGRATED_PREFIX = 'mr_seen_legacy_migrated_v2_';
 const LEGACY_SEEN_KEYS = [
   'community-media',
   'tour-media',
@@ -243,56 +243,69 @@ function _parseLegacySeenStorageKey(storageKey) {
   return null;
 }
 
-function migrateLegacySeenStateForCurrentUser() {
+async function migrateLegacySeenStateForCurrentUser() {
   const userId = _seenUserId();
   if (!userId || userId === 'anon') return;
   if (state?._legacySeenMigratedForUser === userId) return;
-  state._legacySeenMigratedForUser = userId;
+  if (state?._legacySeenMigrationPromise) return state._legacySeenMigrationPromise;
 
-  const migratedKey = LEGACY_SEEN_MIGRATED_PREFIX + userId;
-  try {
-    if (localStorage.getItem(migratedKey) === '1') return;
-  } catch(e) {}
-
-  let owner = null;
-  try { owner = localStorage.getItem(LEGACY_SEEN_OWNER_KEY); } catch(e) {}
-  if (!owner) {
+  state._legacySeenMigrationPromise = (async () => {
+    const migratedKey = LEGACY_SEEN_MIGRATED_PREFIX + userId;
     try {
-      const hasLegacyKeys = Object.keys(localStorage).some(k => !!_parseLegacySeenStorageKey(k));
-      if (!hasLegacyKeys) return;
-      localStorage.setItem(LEGACY_SEEN_OWNER_KEY, userId);
-      owner = userId;
-    } catch(e) { return; }
-  }
-  if (owner !== userId) return;
-
-  const rowsToSave = [];
-  for (const storageKey of Object.keys(localStorage)) {
-    const parsed = _parseLegacySeenStorageKey(storageKey);
-    if (!parsed) continue;
-    let seenAt = '';
-    try { seenAt = localStorage.getItem(storageKey) || ''; } catch(e) {}
-    if (!Number.isFinite(new Date(seenAt).getTime())) continue;
-
-    const userKey = _seenKey(parsed.scopeId, parsed.seenKey, userId);
-    try {
-      if (!localStorage.getItem(userKey)) localStorage.setItem(userKey, seenAt);
+      if (localStorage.getItem(migratedKey) === '1') {
+        state._legacySeenMigratedForUser = userId;
+        return;
+      }
     } catch(e) {}
 
-    if (!state.seenState) state.seenState = {};
-    const cacheKey = _seenCacheKey(parsed.scopeId, parsed.seenKey, userId);
-    if (!state.seenState[cacheKey]) state.seenState[cacheKey] = seenAt;
+    let owner = null;
+    try { owner = localStorage.getItem(LEGACY_SEEN_OWNER_KEY); } catch(e) {}
+    if (!owner) {
+      try {
+        const hasLegacyKeys = Object.keys(localStorage).some(k => !!_parseLegacySeenStorageKey(k));
+        if (!hasLegacyKeys) {
+          localStorage.setItem(migratedKey, '1');
+          state._legacySeenMigratedForUser = userId;
+          return;
+        }
+        localStorage.setItem(LEGACY_SEEN_OWNER_KEY, userId);
+        owner = userId;
+      } catch(e) { return; }
+    }
+    if (owner !== userId) return;
 
-    rowsToSave.push({ scopeId: parsed.scopeId, seenKey: parsed.seenKey, seenAt });
-  }
+    const rowsToSave = [];
+    for (const storageKey of Object.keys(localStorage)) {
+      const parsed = _parseLegacySeenStorageKey(storageKey);
+      if (!parsed) continue;
+      let seenAt = '';
+      try { seenAt = localStorage.getItem(storageKey) || ''; } catch(e) {}
+      if (!Number.isFinite(new Date(seenAt).getTime())) continue;
 
-  try { localStorage.setItem(migratedKey, '1'); } catch(e) {}
+      const userKey = _seenKey(parsed.scopeId, parsed.seenKey, userId);
+      try {
+        if (!localStorage.getItem(userKey)) localStorage.setItem(userKey, seenAt);
+      } catch(e) {}
 
-  if (typeof saveSeenStatesBulk === 'function' && rowsToSave.length) {
-    saveSeenStatesBulk(rowsToSave).catch(e => {
-      console.warn('[seen_state] legacy migration failed:', e.message || e);
-    });
-  }
+      if (!state.seenState) state.seenState = {};
+      const cacheKey = _seenCacheKey(parsed.scopeId, parsed.seenKey, userId);
+      if (!state.seenState[cacheKey]) state.seenState[cacheKey] = seenAt;
+
+      rowsToSave.push({ scopeId: parsed.scopeId, seenKey: parsed.seenKey, seenAt });
+    }
+
+    if (typeof saveSeenStatesBulk === 'function' && rowsToSave.length) {
+      await saveSeenStatesBulk(rowsToSave);
+    }
+    try { localStorage.setItem(migratedKey, '1'); } catch(e) {}
+    state._legacySeenMigratedForUser = userId;
+  })().catch(e => {
+    console.warn('[seen_state] legacy migration failed:', e.message || e);
+  }).finally(() => {
+    state._legacySeenMigrationPromise = null;
+  });
+
+  return state._legacySeenMigrationPromise;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add persisted-state schema versioning so old app state is discarded after incompatible updates
- guard restored state against user/session mismatches
- await legacy seen-state migration before route/badge data is loaded
- scope seen-state load cache by user to avoid cross-user reuse

## Validation
- node --check js/state.js
- node --check js/utils.js
- node --check js/api.js
- node --check js/auth.js
- node --check js/app.js