### PR TITLE
Fix PWA stale app shell state

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1299,15 +1299,15 @@ async function init() {
     return;
   }
 
-  // iOS/PWA cold start: render persisted state before any Supabase call.
-  // CDN/auth/network calls can stall while offline or captive; cached UI should
-  // still become visible immediately.
+  // iOS/PWA cold start: persisted state is only rendered before auth when
+  // offline. Online we wait for Supabase session/profile first; otherwise an
+  // installed PWA can briefly expose stale cross-version state after updates.
   const restoredAtBoot = restoreState() && !!state.currentUser;
-  if (restoredAtBoot) {
+  if (restoredAtBoot && !navigator.onLine) {
     console.log('[init] Boot mit gespeichertem State');
     state.view = state.currentCommunityId ? 'community-home' : 'communities';
     render();
-    if (!navigator.onLine) return;
+    return;
   } else if (!navigator.onLine) {
     state.authMode = 'login';
     state.authErr  = 'Offline - keine gespeicherten Daten gefunden.';
@@ -1319,8 +1319,9 @@ async function init() {
   try {
     const { data: { session } } = await _withTimeout(sb.auth.getSession(), 3500);
 
-    if (!session && restoredAtBoot) return;
     if (!session) {
+      clearPersistedState();
+      state.currentUser = null;
       state.authMode = 'login';
       state.view     = 'auth';
       render();
@@ -1345,7 +1346,7 @@ async function init() {
       // Vor dem Profile-Fetch: gespeicherten State opportunistisch laden,
       // damit SWR-Fast-Path greifen kann (sofortiges Render mit alten Daten,
       // dann stille Aktualisierung im Hintergrund)
-      if (!restoredAtBoot) restoreState(session.user.id);
+      if (!restoredAtBoot || state.currentUser?.id !== session.user.id) restoreState(session.user.id);
 
       const { data: profile } = await _withTimeout(
         sb
@@ -1356,7 +1357,6 @@ async function init() {
         3500
       );
 
-      if (!profile && restoredAtBoot) return;
       if (profile) {
         state.currentUser = {
           id: session.user.id,
@@ -1385,7 +1385,12 @@ async function init() {
     }
   } catch (e) {
     console.error('[init] session check failed:', e);
-    if (restoredAtBoot) return;
+    if (restoredAtBoot) {
+      state.view = state.currentCommunityId ? 'community-home' : 'communities';
+      render();
+      toast('Verbindung fehlgeschlagen. Zeige gespeicherte Daten.', 'error');
+      return;
+    }
     state.authMode = 'login';
     state.authErr  = navigator.onLine ? 'Verbindung fehlgeschlagen. Bitte später erneut versuchen.' : 'Offline - keine gespeicherten Daten gefunden.';
     state.view     = 'auth';

--- a/js/state.js
+++ b/js/state.js
@@ -77,7 +77,8 @@ const state = {
    offline with previously cached data.
    ---------------------------------------------------------- */
 const STATE_STORAGE_KEY = 'motoroute_state_v1';
-const STATE_SCHEMA_VERSION = 2;
+const STATE_SCHEMA_VERSION = 3;
+const STATE_APP_VERSION = (typeof APP_VERSION !== 'undefined' && APP_VERSION) ? APP_VERSION : 'dev';
 const STATE_MAX_AGE_MS  = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 function persistState() {
@@ -86,6 +87,7 @@ function persistState() {
     // Convert Sets and other non-serializable values to plain types
     const snap = {
       schemaVersion: STATE_SCHEMA_VERSION,
+      appVersion: STATE_APP_VERSION,
       ts: Date.now(),
       currentUser:        state.currentUser,
       currentCommunityId: state.currentCommunityId,
@@ -135,6 +137,10 @@ function restoreState(expectedUserId) {
       localStorage.removeItem(STATE_STORAGE_KEY);
       return false;
     }
+    if (STATE_APP_VERSION !== 'dev' && snap.appVersion && snap.appVersion !== STATE_APP_VERSION) {
+      localStorage.removeItem(STATE_STORAGE_KEY);
+      return false;
+    }
     if (expectedUserId && snap.currentUser?.id !== expectedUserId) {
       localStorage.removeItem(STATE_STORAGE_KEY);
       return false;
@@ -153,6 +159,7 @@ function restoreState(expectedUserId) {
     );
     delete state.ts;
     delete state.schemaVersion;
+    delete state.appVersion;
     return true;
   } catch (e) {
     console.warn('[restoreState]', e);

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
    Handles: offline caching + Web Push Notifications
    ============================================================ */
 
-const CACHE_NAME = 'motoroute-v9';
+const CACHE_NAME = 'motoroute-v10';
 const API_CACHE_NAME  = 'motoroute-api-v1';
 const TILE_CACHE_NAME = 'motoroute-tiles-v1';
 const TILE_CACHE_MAX  = 500; // ~500 Tiles × ø20 KB = max ~10 MB
@@ -55,8 +55,31 @@ self.addEventListener('activate', event => {
   );
 });
 
+function isAppShellRequest(event, url) {
+  if (url.origin !== self.location.origin || event.request.method !== 'GET') return false;
+  if (event.request.mode === 'navigate') return true;
+  return /\.(?:html|css|js|json|webmanifest)$/i.test(url.pathname);
+}
+
+function networkFirstWithCache(event, fallbackUrl) {
+  event.respondWith(
+    caches.open(CACHE_NAME).then(async cache => {
+      try {
+        const response = await fetch(event.request);
+        if (response.ok) cache.put(event.request, response.clone());
+        return response;
+      } catch (e) {
+        const cached = await cache.match(event.request);
+        if (cached) return cached;
+        if (fallbackUrl) return cache.match(fallbackUrl);
+        return undefined;
+      }
+    })
+  );
+}
+
 /* ----------------------------------------------------------
-   Fetch – Network-first für API, Cache-first für Assets
+   Fetch – Network-first für API/App-Shell, Cache-first für Tiles/Images
    ---------------------------------------------------------- */
 self.addEventListener('fetch', event => {
   const url = new URL(event.request.url);
@@ -138,6 +161,14 @@ self.addEventListener('fetch', event => {
     return; // Browser-Standard
   }
 
+  // App-Shell (HTML/CSS/JS/Manifest): online immer frisch laden.
+  // Wichtig für installierte PWAs: cache-first kann sonst nach Deploys alte
+  // JS-Dateien mit neuem Serverstand mischen.
+  if (isAppShellRequest(event, url)) {
+    networkFirstWithCache(event, event.request.mode === 'navigate' ? '/index.html' : null);
+    return;
+  }
+
   // Karten-Tiles (OpenStreetMap) — Cache-first, Größenlimit
   if (url.hostname.includes('tile.openstreetmap.org')) {
     event.respondWith(
@@ -170,7 +201,7 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // App-Shell: Cache-first, Fallback auf Network
+  // Statische Medien: Cache-first, Fallback auf Network
   event.respondWith(
     caches.match(event.request).then(cached => {
       if (cached) return cached;


### PR DESCRIPTION
## Summary
- make PWA app-shell assets load network-first so installed apps do not run stale JS/CSS after deploys
- add app-version-aware persisted state validation and bump state schema to discard incompatible cached state
- wait for Supabase session/profile before rendering cached state while online; keep offline cached startup

## Validation
- node --check sw.js
- node --check js/state.js
- node --check js/app.js