### PR TITLE
Fix PWA state and weather radar layout

### DIFF
--- a/css/theme-premium.css
+++ b/css/theme-premium.css
@@ -947,6 +947,7 @@ html, body {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 16px;
   margin-bottom: 18px;
 }
@@ -955,6 +956,12 @@ html, body {
   font-size: 28px;
   letter-spacing: 1px;
   margin: 0;
+}
+.tour-weather-title-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
 }
 .tour-weather-select-wrap {
   display: flex;
@@ -1196,6 +1203,12 @@ html, body {
   display: flex;
   align-items: flex-end;
   gap: 8px;
+}
+@media (max-width: 600px) {
+  .tour-weather-controls,
+  .tour-weather-select-wrap {
+    width: 100%;
+  }
 }
 .rain-radar-overlay {
   position: fixed;

--- a/js/render.js
+++ b/js/render.js
@@ -1194,7 +1194,10 @@ function renderWeatherTab(tour) {
   return `<div class="tab-scroll">
     <div class="tour-weather-layout">
       <div class="tour-weather-head">
-        <h2>Wetter</h2>
+        <div class="tour-weather-title-block">
+          <h2>Wetter</h2>
+          <button class="btn btn-primary btn-sm" id="tour-weather-radar">Regenradar</button>
+        </div>
         <div class="tour-weather-controls">
           <label class="tour-weather-select-wrap">
             <span>Wetter für</span>
@@ -1202,7 +1205,6 @@ function renderWeatherTab(tour) {
               ${options.map(o => `<option value="${esc(o.value)}" ${selected?.value === o.value ? 'selected' : ''}>${esc(o.label)}</option>`).join('')}
             </select>
           </label>
-          <button class="btn btn-primary btn-sm" id="tour-weather-radar">Regenradar</button>
         </div>
       </div>
       <div id="tour-weather-body">


### PR DESCRIPTION
## Summary
- make PWA app-shell assets load network-first so installed apps do not run stale JS/CSS after deploys
- add app-version-aware persisted state validation and wait for Supabase session/profile before online cached rendering
- move the Regenradar button below the Wetter title in the tour weather tab

## Validation
- node --check sw.js
- node --check js/state.js
- node --check js/app.js
- node --check js/render.js