### PR TITLE
Add route metadata for weather locations

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -3,6 +3,22 @@
    Depends on: config.js (sb), state.js (state)
    ============================================================ */
 
+const TOUR_LIST_SELECT = [
+  'id',
+  'community_id',
+  'admin_id',
+  'co_admin_ids',
+  'name',
+  'date',
+  'end_date',
+  'destination',
+  'description',
+  'distance',
+  'surface_display',
+  'route_metadata',
+  'created_at',
+].join(',');
+
 /* ----------------------------------------------------------
    User seen-state (badges / banners)
    ---------------------------------------------------------- */
@@ -164,8 +180,9 @@ async function loadHomeData() {
     return;
   }
 
-  // Load tours for this community
-  const toursRes = await sb.from('tours').select('*')
+  // Load only list metadata. Full GPX JSON is fetched lazily for tour detail
+  // or the planning map, otherwise every home render burns PostgREST egress.
+  const toursRes = await sb.from('tours').select(TOUR_LIST_SELECT)
     .eq('community_id', cid)
     .order('date', { ascending: true });
 
@@ -713,10 +730,12 @@ async function deletePlanDate(id) {
  * @param {Array} route
  */
 async function saveGPX(route, gpxText = '') {
+  const routeMetadata = typeof buildRouteMetadata === 'function' ? buildRouteMetadata(route) : null;
   const { error } = await sb
     .from('tours')
     .update({
       gpx_route: route,
+      route_metadata: routeMetadata,
       surface_analysis: null,
       surface_display: null,
       surface_analysis_updated_at: null,
@@ -726,6 +745,7 @@ async function saveGPX(route, gpxText = '') {
   const hadRoute = !!state.currentTour?.gpx_route;
   if (state.currentTour) {
     state.currentTour.gpx_route = route;
+    state.currentTour.route_metadata = routeMetadata;
     state.currentTour.surface_analysis = null;
     state.currentTour.surface_display = null;
     state.currentTour.surface_analysis_updated_at = null;
@@ -795,6 +815,7 @@ async function deleteGPX() {
     .from('tours')
     .update({
       gpx_route: null,
+      route_metadata: null,
       surface_analysis: null,
       surface_display: null,
       surface_analysis_updated_at: null,
@@ -803,6 +824,7 @@ async function deleteGPX() {
   if (error) throw new Error(error.message);
   if (state.currentTour) {
     state.currentTour.gpx_route = null;
+    state.currentTour.route_metadata = null;
     state.currentTour.surface_analysis = null;
     state.currentTour.surface_display = null;
     state.currentTour.surface_analysis_updated_at = null;
@@ -1079,7 +1101,8 @@ async function createCommunity(name, password) {
 async function loadPlanningData() {
   const cid = state.currentCommunityId;
 
-  // Load tours, polls, messages and changelog all in parallel — all independent
+  // Planning overview needs only tour metadata for the calendar. Route geometry
+  // is loaded separately by loadPlanningMapRoutes() when the map tab is opened.
   const [
     { data: tours },
     { data: polls },
@@ -1087,9 +1110,9 @@ async function loadPlanningData() {
     { data: log },
   ] = await Promise.all([
     sb.from('tours')
-      .select('id, name, gpx_route, surface_analysis, date, end_date')
+      .select(TOUR_LIST_SELECT)
       .eq('community_id', cid)
-      .not('gpx_route', 'is', null),
+      .order('date', { ascending: true }),
     sb.from('community_polls')
       .select('*')
       .eq('community_id', cid)
@@ -1103,6 +1126,9 @@ async function loadPlanningData() {
       .eq('community_id', cid)
       .order('created_at', { ascending: false }),
   ]);
+
+  state.tours = tours || [];
+  state._loadedPlanningForCid = cid;
 
   state.communityMessages  = msgs || [];
   state.communityChangelog = log  || [];
@@ -1130,13 +1156,40 @@ async function loadPlanningData() {
     });
   }
 
-  // Init plan map visibility (all tours visible by default)
-  (tours || []).forEach(t => {
+  if (state._loadedPlanMapRoutesCid !== cid) state.communityToursGpx = [];
+}
+
+async function loadPlanningMapRoutes() {
+  const cid = state.currentCommunityId;
+  if (!cid) return;
+  if (!navigator.onLine && state._loadedPlanMapRoutesCid === cid && state.communityToursGpx) return;
+  if (state._loadedPlanMapRoutesCid === cid && state.communityToursGpx?.length) return;
+
+  const { data } = await sb.from('tours')
+    .select('id, name, gpx_route, route_metadata, date, end_date')
+    .eq('community_id', cid)
+    .not('gpx_route', 'is', null)
+    .order('date', { ascending: true });
+
+  state.communityToursGpx = data || [];
+  state._loadedPlanMapRoutesCid = cid;
+  state.communityToursGpx.forEach(t => {
     if (state.planMapVisible[t.id] === undefined) state.planMapVisible[t.id] = true;
   });
+}
 
-  // Store tours with gpx for plan map
-  state.communityToursGpx = tours || [];
+async function loadTourRouteGeometry(tourId) {
+  if (!tourId) return null;
+  const { data } = await sb.from('tours')
+    .select('id, gpx_route, route_metadata, surface_analysis, surface_display')
+    .eq('id', tourId)
+    .single();
+  if (!data) return null;
+
+  const mergeRouteFields = t => t?.id === tourId ? { ...t, ...data } : t;
+  state.tours = (state.tours || []).map(mergeRouteFields);
+  if (state.currentTour?.id === tourId) Object.assign(state.currentTour, data);
+  return data;
 }
 
 /**

--- a/js/app.js
+++ b/js/app.js
@@ -172,6 +172,7 @@ async function _loadViewData(view) {
 
     if (view === 'planning') {
       await loadPlanningData();
+      if (state.planningTab === 'map') await loadPlanningMapRoutes();
       markTabSeen(state.currentCommunityId, 'plan-chat');
       markTabSeen(state.currentCommunityId, 'plan-polls');
       state.planningBadges = { chat: 0, polls: 0 };
@@ -227,12 +228,14 @@ async function navigateTo(view, params = {}) {
     const _isOffline = !navigator.onLine;
     const _hasCommData = (state.communities?.length || 0) > 0;
     const _hasHomeData = (state.tours?.length || 0) > 0 && state._loadedHomeForCid === state.currentCommunityId;
+    const _hasPlanningData = (state.communityPolls?.length || state.communityMessages?.length || state.communityChangelog?.length || state.tours?.length)
+      && state._loadedPlanningForCid === state.currentCommunityId;
     const _hasTourData = state.currentTour?.id === state.currentTourId;
     const _canRenderNow = (
       (view === 'communities'    && _hasCommData) ||
       (view === 'community-home' && _hasHomeData) ||
       (view === 'community-media'&& _hasHomeData) ||
-      (view === 'planning'       && _hasHomeData) ||
+      (view === 'planning'       && (_hasHomeData || _hasPlanningData)) ||
       (view === 'tour'           && _hasTourData)
     );
 
@@ -485,23 +488,28 @@ function getTourWeatherOptions(tour = state.currentTour) {
     });
   }
 
-  const gpx = normalizeGPXRoute(tour?.gpx_route);
-  (gpx?.tracks || []).forEach((track, trackIndex) => {
-    const points = (track.points || []).filter(p => Number.isFinite(p?.[0]) && Number.isFinite(p?.[1]));
-    if (!points.length) return;
-    const trackName = track.name || `Track ${trackIndex + 1}`;
+  const routeMetadata = tour?.route_metadata || (typeof buildRouteMetadata === 'function' ? buildRouteMetadata(tour?.gpx_route) : null);
+  (routeMetadata?.tracks || []).forEach((track, trackIndex) => {
+    const routeTrackIndex = Number.isFinite(Number(track.index)) ? Number(track.index) : trackIndex;
+    const trackName = track.name || `Track ${routeTrackIndex + 1}`;
     [
-      ['start', 'Anfang', 0],
-      ['middle', 'Mitte', 0.5],
-      ['end', 'Ende', 1],
-    ].forEach(([pos, label, fraction]) => {
+      ['start', 'Anfang'],
+      ['middle', 'Mitte'],
+      ['end', 'Ende'],
+    ].forEach(([pos, label]) => {
+      const point = track[pos];
+      const lat = Number(point?.lat);
+      const lon = Number(point?.lon ?? point?.lng);
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
       options.push({
-        value: `track:${trackIndex}:${pos}`,
+        value: `track:${routeTrackIndex}:${pos}`,
         label: `${trackName} ${label}`,
         source: `${trackName} ${label}`,
         detail: trackName,
-        trackIndex,
-        fraction,
+        trackIndex: routeTrackIndex,
+        position: pos,
+        latitude: lat,
+        longitude: lon,
       });
     });
   });
@@ -555,15 +563,38 @@ async function resolveTourWeatherChoice(choice, tour = state.currentTour) {
     return coords ? { ...coords, label: choice.label, source: choice.source } : null;
   }
 
+  const directLat = Number(choice.latitude);
+  const directLon = Number(choice.longitude);
+  if (Number.isFinite(directLat) && Number.isFinite(directLon)) {
+    return {
+      latitude: directLat,
+      longitude: directLon,
+      label: choice.label,
+      source: choice.source,
+    };
+  }
+
   const match = choice.value.match(/^track:(\d+):(start|middle|end)$/);
   if (!match) return null;
   const trackIndex = Number(match[1]);
+  const routeMetadata = tour.route_metadata || (typeof buildRouteMetadata === 'function' ? buildRouteMetadata(tour.gpx_route) : null);
+  const metaTrack = (routeMetadata?.tracks || []).find(t => Number(t.index) === trackIndex);
+  const metaPoint = metaTrack?.[match[2]];
+  const metaLat = Number(metaPoint?.lat);
+  const metaLon = Number(metaPoint?.lon ?? metaPoint?.lng);
+  if (Number.isFinite(metaLat) && Number.isFinite(metaLon)) {
+    return { latitude: metaLat, longitude: metaLon, label: choice.label, source: choice.source };
+  }
+
   const gpx = normalizeGPXRoute(tour.gpx_route);
   const points = (gpx?.tracks?.[trackIndex]?.points || []).filter(p => Number.isFinite(p?.[0]) && Number.isFinite(p?.[1]));
-  const point = _trackPointAtFraction(points, choice.fraction);
+  const fraction = match[2] === 'middle' ? 0.5 : match[2] === 'end' ? 1 : 0;
+  const point = typeof routePointAtFraction === 'function'
+    ? routePointAtFraction(points, fraction)
+    : _trackPointAtFraction(points, fraction);
   return point ? {
-    latitude: point[0],
-    longitude: point[1],
+    latitude: Array.isArray(point) ? point[0] : point.lat,
+    longitude: Array.isArray(point) ? point[1] : point.lon,
     label: choice.label,
     source: choice.source,
   } : null;
@@ -1135,7 +1166,10 @@ async function _loadCheckinWeather(tourId, destination, startDate, endDate, maps
   const WEATHER_CACHE_MAX_AGE_MS = 60 * 60 * 1000;
   const now = Date.now();
   const today = new Date(now).toISOString().slice(0, 10);
-  const cacheKey = ['v3', destination || '', startDate || '', endDate || '', mapsLink || '', tour?.gpx_route ? 'gpx' : ''].join('|');
+  const routeMetaKey = tour?.route_metadata
+    ? `${tour.route_metadata.trackCount || 0}:${tour.route_metadata.waypointCount || 0}`
+    : (tour?.gpx_route ? 'gpx' : '');
+  const cacheKey = ['v4', destination || '', startDate || '', endDate || '', mapsLink || '', routeMetaKey].join('|');
   const cached = state.weatherCache[tourId];
   const cachedFetchedAt = cached?.fetchedAt
     || (cached?.fetchDate ? Date.parse(`${cached.fetchDate}T00:00:00`) : 0);
@@ -1172,6 +1206,24 @@ async function _loadCheckinWeather(tourId, destination, startDate, endDate, maps
         if (geoData.results?.length) ({ latitude, longitude } = geoData.results[0]);
       }
       if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+        let routeMetadata = tour?.route_metadata;
+        if (!routeMetadata && tour?.gpx_route && typeof buildRouteMetadata === 'function') {
+          routeMetadata = buildRouteMetadata(tour.gpx_route);
+          tour.route_metadata = routeMetadata;
+        }
+        const firstMetaPoint = routeMetadata?.tracks?.[0]?.start;
+        const metaLat = Number(firstMetaPoint?.lat);
+        const metaLon = Number(firstMetaPoint?.lon ?? firstMetaPoint?.lng);
+        if (Number.isFinite(metaLat) && Number.isFinite(metaLon)) {
+          latitude = metaLat;
+          longitude = metaLon;
+        }
+      }
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+        if (!tour?.gpx_route && typeof loadTourRouteGeometry === 'function') {
+          const routeFields = await loadTourRouteGeometry(tourId);
+          if (routeFields && tour) Object.assign(tour, routeFields);
+        }
         const gpx = normalizeGPXRoute(tour?.gpx_route);
         const firstPoint = (gpx?.tracks || [])
           .flatMap(track => track.points || [])

--- a/js/events.js
+++ b/js/events.js
@@ -614,7 +614,7 @@ function attachEvents() {
     const treffpunktLink = nextTour
       ? (state.tourPlanDates || []).find(pd => pd.type === 'treffpunkt' && pd.maps_link)?.maps_link
       : null;
-    if (nextTour && (nextTour.destination || treffpunktLink || nextTour.gpx_route)) {
+    if (nextTour) {
       _loadCheckinWeather(nextTour.id, nextTour.destination, nextTour.date, nextTour.end_date || nextTour.date, treffpunktLink, nextTour);
     }
   }
@@ -1477,7 +1477,13 @@ function attachPlanningTabHandlers() {
 
       switch (state.planningTab) {
         case 'polls': tc.innerHTML = renderPlanPolls();  attachPlanningContentEvents(); break;
-        case 'map':   tc.innerHTML = renderPlanMap();    _initPlanMap(); attachPlanningContentEvents(); break;
+        case 'map':
+          tc.innerHTML = '<div class="weather-loading">Routen werden geladen…</div>';
+          await loadPlanningMapRoutes();
+          tc.innerHTML = renderPlanMap();
+          _initPlanMap();
+          attachPlanningContentEvents();
+          break;
         case 'chat':  tc.innerHTML = renderPlanChat();   _scrollPlanChat(); attachPlanningContentEvents(); break;
         case 'log':   tc.innerHTML = renderPlanLog();    break;
       }
@@ -1495,7 +1501,16 @@ function attachPlanningTabHandlers() {
   );
 
   /* Init content for initial tab */
-  if (state.planningTab === 'map') setTimeout(_initPlanMap, 80);
+  if (state.planningTab === 'map') {
+    loadPlanningMapRoutes().then(() => {
+      const tc = document.getElementById('plan-tab-content');
+      if (tc && state.view === 'planning' && state.planningTab === 'map') {
+        tc.innerHTML = renderPlanMap();
+        attachPlanningContentEvents();
+        setTimeout(_initPlanMap, 80);
+      }
+    });
+  }
   if (state.planningTab === 'chat') _scrollPlanChat();
 }
 

--- a/js/state.js
+++ b/js/state.js
@@ -77,7 +77,7 @@ const state = {
    offline with previously cached data.
    ---------------------------------------------------------- */
 const STATE_STORAGE_KEY = 'motoroute_state_v1';
-const STATE_SCHEMA_VERSION = 3;
+const STATE_SCHEMA_VERSION = 5;
 const STATE_APP_VERSION = (typeof APP_VERSION !== 'undefined' && APP_VERSION) ? APP_VERSION : 'dev';
 const STATE_MAX_AGE_MS  = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -117,6 +117,7 @@ function persistState() {
       // SWR fast-path flags
       _loadedCommunityDataId:    state._loadedCommunityDataId,
       _loadedHomeForCid:         state._loadedHomeForCid,
+      _loadedPlanningForCid:     state._loadedPlanningForCid,
       _loadedMediaForCid:        state._loadedMediaForCid,
       _loadedPlanDatesTourId:    state._loadedPlanDatesTourId,
       _loadedTourMediaCountsCid: state._loadedTourMediaCountsCid,

--- a/js/utils.js
+++ b/js/utils.js
@@ -64,6 +64,98 @@ function formatSurfaceDistance(kilometers) {
     : `${value.toLocaleString('de-DE', { maximumFractionDigits: 1 })} km`;
 }
 
+function _routePointToLatLon(point) {
+  if (!point) return null;
+  const lat = Number(Array.isArray(point) ? point[0] : point.lat);
+  const lon = Number(Array.isArray(point) ? point[1] : (point.lon ?? point.lng));
+  return Number.isFinite(lat) && Number.isFinite(lon) ? { lat, lon } : null;
+}
+
+function _routeHaversine(a, b) {
+  const pa = _routePointToLatLon(a);
+  const pb = _routePointToLatLon(b);
+  if (!pa || !pb) return 0;
+  const R = 6371;
+  const dLat = (pb.lat - pa.lat) * Math.PI / 180;
+  const dLon = (pb.lon - pa.lon) * Math.PI / 180;
+  const la1 = pa.lat * Math.PI / 180;
+  const la2 = pb.lat * Math.PI / 180;
+  const h = Math.sin(dLat / 2) ** 2
+    + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}
+
+function routePointAtFraction(points, fraction) {
+  const pts = (points || []).map(_routePointToLatLon).filter(Boolean);
+  if (!pts.length) return null;
+  if (fraction <= 0 || pts.length === 1) return pts[0];
+  if (fraction >= 1) return pts[pts.length - 1];
+
+  const distances = [];
+  let total = 0;
+  for (let i = 1; i < pts.length; i++) {
+    const d = _routeHaversine(pts[i - 1], pts[i]);
+    distances.push(d);
+    total += d;
+  }
+  if (!total) return pts[Math.floor(pts.length * fraction)] || pts[0];
+
+  const target = total * fraction;
+  let walked = 0;
+  for (let i = 1; i < pts.length; i++) {
+    const segment = distances[i - 1];
+    if (walked + segment >= target) {
+      const ratio = segment ? (target - walked) / segment : 0;
+      const a = pts[i - 1];
+      const b = pts[i];
+      return {
+        lat: a.lat + (b.lat - a.lat) * ratio,
+        lon: a.lon + (b.lon - a.lon) * ratio,
+      };
+    }
+    walked += segment;
+  }
+  return pts[pts.length - 1];
+}
+
+function buildRouteMetadata(gpxRoute) {
+  const gpx = typeof normalizeGPXRoute === 'function'
+    ? normalizeGPXRoute(gpxRoute)
+    : gpxRoute;
+  if (!gpx) return null;
+
+  const bounds = { minLat: Infinity, minLon: Infinity, maxLat: -Infinity, maxLon: -Infinity };
+  const tracks = (gpx.tracks || []).map((track, index) => {
+    const points = (track.points || []).map(_routePointToLatLon).filter(Boolean);
+    points.forEach(p => {
+      bounds.minLat = Math.min(bounds.minLat, p.lat);
+      bounds.minLon = Math.min(bounds.minLon, p.lon);
+      bounds.maxLat = Math.max(bounds.maxLat, p.lat);
+      bounds.maxLon = Math.max(bounds.maxLon, p.lon);
+    });
+    return {
+      index,
+      name: track.name || `Track ${index + 1}`,
+      color: track.color || null,
+      pointCount: points.length,
+      start: routePointAtFraction(points, 0),
+      middle: routePointAtFraction(points, 0.5),
+      end: routePointAtFraction(points, 1),
+    };
+  }).filter(t => t.pointCount > 0);
+
+  const hasBounds = Number.isFinite(bounds.minLat) && Number.isFinite(bounds.minLon)
+    && Number.isFinite(bounds.maxLat) && Number.isFinite(bounds.maxLon);
+
+  return {
+    version: 1,
+    trackCount: tracks.length,
+    waypointCount: (gpx.waypoints || []).length,
+    bounds: hasBounds ? bounds : null,
+    tracks,
+  };
+}
+
 /**
  * Build a collision-aware initials map for a list of user IDs.
  * Uses 1st + 2nd char, escalating to 1st + 3rd, 4th, … when two users share the same result.

--- a/supabase/migrations/20260508191303_reduce_postgrest_egress_io.sql
+++ b/supabase/migrations/20260508191303_reduce_postgrest_egress_io.sql
@@ -1,0 +1,151 @@
+-- Store tiny route metadata next to the full GPX JSON. Weather/location
+-- features can use this instead of downloading gpx_route from PostgREST.
+
+alter table public.tours
+  add column if not exists route_metadata jsonb;
+
+create or replace function public.build_route_metadata(gpx jsonb)
+returns jsonb
+language plpgsql
+immutable
+as $$
+declare
+  tracks_json jsonb;
+  waypoints_json jsonb;
+  track jsonb;
+  points jsonb;
+  p jsonb;
+  start_p jsonb;
+  middle_p jsonb;
+  end_p jsonb;
+  points_len int;
+  idx int := 0;
+  track_rows jsonb := '[]'::jsonb;
+  min_lat double precision := null;
+  min_lon double precision := null;
+  max_lat double precision := null;
+  max_lon double precision := null;
+  lat double precision;
+  lon double precision;
+begin
+  if gpx is null then
+    return null;
+  end if;
+
+  if jsonb_typeof(gpx) = 'array' then
+    tracks_json := jsonb_build_array(jsonb_build_object('name', 'Route', 'points', gpx));
+    waypoints_json := '[]'::jsonb;
+  else
+    tracks_json := coalesce(gpx->'tracks', '[]'::jsonb);
+    waypoints_json := coalesce(gpx->'waypoints', '[]'::jsonb);
+  end if;
+
+  for track in select value from jsonb_array_elements(tracks_json)
+  loop
+    points := coalesce(track->'points', '[]'::jsonb);
+    if jsonb_typeof(points) <> 'array' then
+      idx := idx + 1;
+      continue;
+    end if;
+
+    points_len := jsonb_array_length(points);
+    if points_len = 0 then
+      idx := idx + 1;
+      continue;
+    end if;
+
+    for p in select value from jsonb_array_elements(points)
+    loop
+      if jsonb_typeof(p) = 'array' and jsonb_array_length(p) >= 2 then
+        lat := (p->>0)::double precision;
+        lon := (p->>1)::double precision;
+        min_lat := least(coalesce(min_lat, lat), lat);
+        min_lon := least(coalesce(min_lon, lon), lon);
+        max_lat := greatest(coalesce(max_lat, lat), lat);
+        max_lon := greatest(coalesce(max_lon, lon), lon);
+      end if;
+    end loop;
+
+    start_p := points->0;
+    middle_p := points->(((points_len - 1) / 2)::int);
+    end_p := points->(points_len - 1);
+
+    track_rows := track_rows || jsonb_build_array(jsonb_build_object(
+      'index', idx,
+      'name', coalesce(nullif(track->>'name', ''), 'Track ' || (idx + 1)),
+      'color', track->>'color',
+      'pointCount', points_len,
+      'start', jsonb_build_object('lat', (start_p->>0)::double precision, 'lon', (start_p->>1)::double precision),
+      'middle', jsonb_build_object('lat', (middle_p->>0)::double precision, 'lon', (middle_p->>1)::double precision),
+      'end', jsonb_build_object('lat', (end_p->>0)::double precision, 'lon', (end_p->>1)::double precision)
+    ));
+
+    idx := idx + 1;
+  end loop;
+
+  return jsonb_build_object(
+    'version', 1,
+    'trackCount', jsonb_array_length(track_rows),
+    'waypointCount', case when jsonb_typeof(waypoints_json) = 'array' then jsonb_array_length(waypoints_json) else 0 end,
+    'bounds', case when min_lat is null then null else jsonb_build_object(
+      'minLat', min_lat,
+      'minLon', min_lon,
+      'maxLat', max_lat,
+      'maxLon', max_lon
+    ) end,
+    'tracks', track_rows
+  );
+end;
+$$;
+
+update public.tours
+set route_metadata = public.build_route_metadata(gpx_route)
+where gpx_route is not null
+  and route_metadata is null;
+
+create or replace function public.set_tour_route_metadata()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.gpx_route is null then
+    new.route_metadata := null;
+  elsif tg_op = 'INSERT' then
+    new.route_metadata := public.build_route_metadata(new.gpx_route);
+  elsif new.gpx_route is distinct from old.gpx_route then
+    new.route_metadata := public.build_route_metadata(new.gpx_route);
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_set_tour_route_metadata on public.tours;
+create trigger trg_set_tour_route_metadata
+before insert or update of gpx_route on public.tours
+for each row execute function public.set_tour_route_metadata();
+
+-- Reduce Disk IO for badge/count queries that filter by scope + created_at.
+-- Existing single-column scope indexes are still useful, but these composite
+-- indexes let Postgres jump directly to the time range for "new since seen".
+
+create index if not exists idx_messages_tour_created_at
+  on public.messages (tour_id, created_at);
+
+create index if not exists idx_change_log_tour_created_at
+  on public.change_log (tour_id, created_at);
+
+create index if not exists idx_tour_media_tour_created_at
+  on public.tour_media (tour_id, created_at);
+
+create index if not exists idx_community_messages_community_created_at
+  on public.community_messages (community_id, created_at);
+
+create index if not exists idx_community_polls_community_created_at
+  on public.community_polls (community_id, created_at);
+
+create index if not exists idx_community_media_community_created_at
+  on public.community_media (community_id, created_at);
+
+-- Route-heavy screens load route JSON only for tours in the current community.
+create index if not exists idx_tours_community_date
+  on public.tours (community_id, date);


### PR DESCRIPTION
## Summary
- add route_metadata for tours with backfill and trigger support in Supabase
- use route metadata for weather dropdown locations, rain index points, and check-in weather fallback
- avoid loading full GPX JSON in home/planning list queries and add composite indexes for badge/count queries

## Database
- Applied remote migration: 20260508191303_reduce_postgrest_egress_io.sql

## Validation
- node --check js/utils.js
- node --check js/api.js
- node --check js/app.js
- node --check js/events.js
- node --check js/state.js
- supabase db push --yes