### PR TITLE
Further reduce route and badge egress

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -19,6 +19,16 @@ const TOUR_LIST_SELECT = [
   'created_at',
 ].join(',');
 
+const TOUR_DETAIL_SELECT = [
+  TOUR_LIST_SELECT,
+  'surface_analysis',
+  'surface_analysis_updated_at',
+].join(',');
+
+const TOUR_MESSAGE_SELECT = 'id,tour_id,user_id,username,text,created_at';
+const TOUR_CHANGELOG_SELECT = 'id,tour_id,user_id,username,field,old_value,new_value,created_at';
+const TOUR_INITIAL_LIMIT = 50;
+
 /* ----------------------------------------------------------
    User seen-state (badges / banners)
    ---------------------------------------------------------- */
@@ -245,30 +255,28 @@ async function computeHomeBadges() {
   if (!myTourIds.length) return;
   await loadSeenStates(myTourIds);
 
-  // For each tour, find events newer than last-seen timestamp
-  await Promise.all(myTourIds.map(async tourId => {
-    const seenChat = getLastSeen(tourId, 'chat');
-    const seenLog  = getLastSeen(tourId, 'changelog');
+  const chatSeen = {};
+  const changelogSeen = {};
+  myTourIds.forEach(tourId => {
+    chatSeen[tourId] = getLastSeen(tourId, 'chat').toISOString();
+    changelogSeen[tourId] = getLastSeen(tourId, 'changelog').toISOString();
+  });
 
-    const [msgsRes, logRes] = await Promise.all([
-      sb.from('messages')
-        .select('id', { count: 'exact', head: true })
-        .eq('tour_id', tourId)
-        .neq('user_id', state.currentUser.id)
-        .gt('created_at', seenChat.toISOString()),
-      sb.from('change_log')
-        .select('id', { count: 'exact', head: true })
-        .eq('tour_id', tourId)
-        .neq('user_id', state.currentUser.id)
-        .gt('created_at', seenLog.toISOString()),
-    ]);
+  const { data, error } = await sb.rpc('get_home_badges', {
+    p_tour_ids: myTourIds,
+    p_chat_seen: chatSeen,
+    p_changelog_seen: changelogSeen,
+  });
+  if (error) {
+    console.warn('[home badges]', error.message);
+    return;
+  }
 
-    const chat      = msgsRes.count || 0;
-    const changelog = logRes.count  || 0;
-    if (chat > 0 || changelog > 0) {
-      state.homeBadges[tourId] = { chat, changelog };
-    }
-  }));
+  (data || []).forEach(row => {
+    const chat = Number(row.chat_count || 0);
+    const changelog = Number(row.changelog_count || 0);
+    if (chat > 0 || changelog > 0) state.homeBadges[row.tour_id] = { chat, changelog };
+  });
 }
 
 /* ----------------------------------------------------------
@@ -282,15 +290,15 @@ async function computeHomeBadges() {
  */
 async function loadTourData(tourId) {
   const [tourRes, membersRes, msgsRes, datesRes, changelogRes] = await Promise.all([
-    sb.from('tours').select('*').eq('id', tourId).single(),
+    sb.from('tours').select(TOUR_DETAIL_SELECT).eq('id', tourId).single(),
     sb.from('tour_members').select('user_id').eq('tour_id', tourId),
-    sb.from('messages').select('*').eq('tour_id', tourId).order('created_at', { ascending: true }),
+    sb.from('messages').select(TOUR_MESSAGE_SELECT).eq('tour_id', tourId).order('created_at', { ascending: false }).limit(TOUR_INITIAL_LIMIT),
     sb.from('plan_dates').select('*').eq('tour_id', tourId).order('date', { ascending: true }),
-    sb.from('change_log').select('*').eq('tour_id', tourId).order('created_at', { ascending: false }),
+    sb.from('change_log').select(TOUR_CHANGELOG_SELECT).eq('tour_id', tourId).order('created_at', { ascending: false }).limit(TOUR_INITIAL_LIMIT),
   ]);
 
   state.currentTour    = tourRes.data;
-  state.tourMessages   = msgsRes.data      || [];
+  state.tourMessages   = (msgsRes.data || []).sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
   state.tourPlanDates  = datesRes.data     || [];
   state.tourChangelog  = changelogRes.data || [];
 
@@ -406,9 +414,10 @@ function _dedupeLogEntries(entries, windowMs = 2 * 60 * 1000) {
 async function loadChangelog() {
   const { data } = await sb
     .from('change_log')
-    .select('*')
+    .select(TOUR_CHANGELOG_SELECT)
     .eq('tour_id', state.currentTourId)
-    .order('created_at', { ascending: false });
+    .order('created_at', { ascending: false })
+    .limit(TOUR_INITIAL_LIMIT);
   state.tourChangelog = data || [];
 }
 
@@ -460,10 +469,11 @@ async function logChange(field, oldValue, newValue) {
 async function loadMessages() {
   const { data } = await sb
     .from('messages')
-    .select('*')
+    .select(TOUR_MESSAGE_SELECT)
     .eq('tour_id', state.currentTourId)
-    .order('created_at', { ascending: true });
-  state.tourMessages = data || [];
+    .order('created_at', { ascending: false })
+    .limit(TOUR_INITIAL_LIMIT);
+  state.tourMessages = (data || []).sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
 }
 
 /* ----------------------------------------------------------
@@ -1166,9 +1176,9 @@ async function loadPlanningMapRoutes() {
   if (state._loadedPlanMapRoutesCid === cid && state.communityToursGpx?.length) return;
 
   const { data } = await sb.from('tours')
-    .select('id, name, gpx_route, route_metadata, date, end_date')
+    .select('id, name, route_metadata, date, end_date')
     .eq('community_id', cid)
-    .not('gpx_route', 'is', null)
+    .not('route_metadata', 'is', null)
     .order('date', { ascending: true });
 
   state.communityToursGpx = data || [];
@@ -1190,6 +1200,13 @@ async function loadTourRouteGeometry(tourId) {
   state.tours = (state.tours || []).map(mergeRouteFields);
   if (state.currentTour?.id === tourId) Object.assign(state.currentTour, data);
   return data;
+}
+
+async function ensureCurrentTourRouteLoaded() {
+  if (!state.currentTourId) return null;
+  if (state.currentTour?.gpx_route) return state.currentTour.gpx_route;
+  const data = await loadTourRouteGeometry(state.currentTourId);
+  return data?.gpx_route || null;
 }
 
 /**

--- a/js/app.js
+++ b/js/app.js
@@ -975,7 +975,8 @@ async function openRainRadarModal() {
     }).addTo(map);
 
     const boundsPoints = [[resolved.latitude, resolved.longitude]];
-    const gpxData = normalizeGPXRoute(tour.gpx_route);
+    const gpxData = normalizeGPXRoute(tour.gpx_route)
+      || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(tour.route_metadata) : null);
     (gpxData?.tracks || []).forEach((track, idx) => {
       const pts = (track.points || []).filter(p => Number.isFinite(p?.[0]) && Number.isFinite(p?.[1]));
       if (!pts.length) return;

--- a/js/events.js
+++ b/js/events.js
@@ -791,6 +791,7 @@ function attachEvents() {
       const tab = card.dataset.goTab;
       if (!tab) return;
       state.currentTab = tab;
+      if (tab === 'map')       await ensureCurrentTourRouteLoaded();
       if (tab === 'chat')      await loadMessages();
       if (tab === 'changelog') await loadChangelog();
       if (tab === 'info' && state.tabBadges.info?.length) {
@@ -807,6 +808,7 @@ function attachEvents() {
   document.querySelectorAll('.tab-btn:not(.plan-tab-btn)').forEach(btn => {
     btn.addEventListener('click', async () => {
       state.currentTab = btn.dataset.tab;
+      if (state.currentTab === 'map')       await ensureCurrentTourRouteLoaded();
       if (state.currentTab === 'chat')      await loadMessages();
       if (state.currentTab === 'changelog') await loadChangelog();
 
@@ -857,6 +859,7 @@ function afterTabRender() {
         const tab = card.dataset.goTab;
         if (!tab) return;
         state.currentTab = tab;
+        if (tab === 'map')       await ensureCurrentTourRouteLoaded();
         if (tab === 'chat')      await loadMessages();
         if (tab === 'changelog') await loadChangelog();
         if (tab === 'info' && state.tabBadges.info?.length) {
@@ -874,9 +877,13 @@ function afterTabRender() {
   }
   if (state.currentTab === 'map') {
     setTimeout(() => {
-      initMap(state.currentTour);
-      attachMapEvents();
-      attachSidebarEvents();
+      ensureCurrentTourRouteLoaded().then(() => {
+        const tc = document.getElementById('tab-content');
+        if (tc && state.currentTour && state.currentTab === 'map') tc.innerHTML = renderTab(state.currentTour);
+        initMap(state.currentTour);
+        attachMapEvents();
+        attachSidebarEvents();
+      });
     }, 80);
   }
   if (state.currentTab === 'chat') {
@@ -934,7 +941,8 @@ function _initOverviewMap() {
     window._tovMapInstance = null;
   }
 
-  const gpxData = normalizeGPXRoute(state.currentTour?.gpx_route);
+  const gpxData = normalizeGPXRoute(state.currentTour?.gpx_route)
+    || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(state.currentTour?.route_metadata) : null);
   if (!gpxData?.tracks?.length) return;
 
   const map = L.map(container, {
@@ -1178,7 +1186,8 @@ function attachMapEvents() {
     }
   });
 
-  document.getElementById('gpx-dl')?.addEventListener('click', () => {
+  document.getElementById('gpx-dl')?.addEventListener('click', async () => {
+    await ensureCurrentTourRouteLoaded();
     downloadGPX(state.currentTour);
   });
 
@@ -1802,7 +1811,8 @@ function _initPlanMap() {
   const allBounds = [];
 
   tours.forEach(t => {
-    const gpx = normalizeGPXRoute(t.gpx_route);
+    const gpx = normalizeGPXRoute(t.gpx_route)
+      || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(t.route_metadata) : null);
     if (!gpx?.tracks?.length) return;
     const visible = state.planMapVisible[t.id] !== false;
 

--- a/js/render.js
+++ b/js/render.js
@@ -1287,7 +1287,8 @@ function _overviewTrackSVG(gpxData) {
 
 function renderTourOverview(tour) {
   const isAdmin  = isCurrentUserAdmin();
-  const gpxData  = normalizeGPXRoute(tour.gpx_route);
+  const gpxData  = normalizeGPXRoute(tour.gpx_route)
+    || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(tour.route_metadata) : null);
   const trackSVG = _overviewTrackSVG(gpxData);
 
   // helper: badge bubble for a tab id
@@ -1299,8 +1300,8 @@ function renderTourOverview(tour) {
   };
 
   // ── MAP CARD ─────────────────────────────────────────────────────────────
-  const trackCount = gpxData?.tracks?.length || 0;
-  const wpCount    = gpxData?.waypoints?.length || 0;
+  const trackCount = tour.route_metadata?.trackCount || gpxData?.tracks?.length || 0;
+  const wpCount    = tour.route_metadata?.waypointCount || gpxData?.waypoints?.length || 0;
 
   const mapBody = (gpxData?.tracks?.length)
     ? `<div id="tov-mini-map" class="tov-map-leaflet"></div>

--- a/js/state.js
+++ b/js/state.js
@@ -77,7 +77,7 @@ const state = {
    offline with previously cached data.
    ---------------------------------------------------------- */
 const STATE_STORAGE_KEY = 'motoroute_state_v1';
-const STATE_SCHEMA_VERSION = 5;
+const STATE_SCHEMA_VERSION = 6;
 const STATE_APP_VERSION = (typeof APP_VERSION !== 'undefined' && APP_VERSION) ? APP_VERSION : 'dev';
 const STATE_MAX_AGE_MS  = 7 * 24 * 60 * 60 * 1000; // 7 days
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -141,6 +141,7 @@ function buildRouteMetadata(gpxRoute) {
       start: routePointAtFraction(points, 0),
       middle: routePointAtFraction(points, 0.5),
       end: routePointAtFraction(points, 1),
+      preview: buildRoutePreviewPoints(points, 120),
     };
   }).filter(t => t.pointCount > 0);
 
@@ -148,12 +149,44 @@ function buildRouteMetadata(gpxRoute) {
     && Number.isFinite(bounds.maxLat) && Number.isFinite(bounds.maxLon);
 
   return {
-    version: 1,
+    version: 2,
     trackCount: tracks.length,
     waypointCount: (gpx.waypoints || []).length,
     bounds: hasBounds ? bounds : null,
     tracks,
   };
+}
+
+function buildRoutePreviewPoints(points, maxPoints = 120) {
+  const pts = (points || []).map(_routePointToLatLon).filter(Boolean);
+  if (pts.length <= maxPoints) return pts;
+  const lastIdx = pts.length - 1;
+  const step = lastIdx / (maxPoints - 1);
+  const preview = [];
+  for (let i = 0; i < maxPoints; i++) {
+    const idx = Math.round(i * step);
+    const p = pts[Math.min(lastIdx, idx)];
+    if (!preview.length || preview[preview.length - 1].lat !== p.lat || preview[preview.length - 1].lon !== p.lon) {
+      preview.push(p);
+    }
+  }
+  return preview;
+}
+
+function routeMetadataToPreviewRoute(routeMetadata) {
+  const tracks = (routeMetadata?.tracks || []).map((track, index) => {
+    const points = (track.preview || [])
+      .map(_routePointToLatLon)
+      .filter(Boolean)
+      .map(p => [p.lat, p.lon]);
+    return {
+      name: track.name || `Track ${index + 1}`,
+      color: track.color || null,
+      points,
+    };
+  }).filter(t => t.points.length > 0);
+  if (!tracks.length) return null;
+  return { tracks, waypoints: [] };
 }
 
 /**

--- a/supabase/migrations/20260508194842_route_preview_and_badge_rpc.sql
+++ b/supabase/migrations/20260508194842_route_preview_and_badge_rpc.sql
@@ -1,0 +1,163 @@
+-- Add route preview points to route_metadata so overview/planning maps can
+-- render without downloading the full gpx_route JSON.
+
+create or replace function public.build_route_metadata(gpx jsonb)
+returns jsonb
+language plpgsql
+immutable
+as $$
+declare
+  tracks_json jsonb;
+  waypoints_json jsonb;
+  track jsonb;
+  points jsonb;
+  p jsonb;
+  preview_rows jsonb;
+  preview_step int;
+  ord int;
+  start_p jsonb;
+  middle_p jsonb;
+  end_p jsonb;
+  points_len int;
+  idx int := 0;
+  track_rows jsonb := '[]'::jsonb;
+  min_lat double precision := null;
+  min_lon double precision := null;
+  max_lat double precision := null;
+  max_lon double precision := null;
+  lat double precision;
+  lon double precision;
+begin
+  if gpx is null then
+    return null;
+  end if;
+
+  if jsonb_typeof(gpx) = 'array' then
+    tracks_json := jsonb_build_array(jsonb_build_object('name', 'Route', 'points', gpx));
+    waypoints_json := '[]'::jsonb;
+  else
+    tracks_json := coalesce(gpx->'tracks', '[]'::jsonb);
+    waypoints_json := coalesce(gpx->'waypoints', '[]'::jsonb);
+  end if;
+
+  for track in select value from jsonb_array_elements(tracks_json)
+  loop
+    points := coalesce(track->'points', '[]'::jsonb);
+    if jsonb_typeof(points) <> 'array' then
+      idx := idx + 1;
+      continue;
+    end if;
+
+    points_len := jsonb_array_length(points);
+    if points_len = 0 then
+      idx := idx + 1;
+      continue;
+    end if;
+
+    for p in select value from jsonb_array_elements(points)
+    loop
+      if jsonb_typeof(p) = 'array' and jsonb_array_length(p) >= 2 then
+        lat := (p->>0)::double precision;
+        lon := (p->>1)::double precision;
+        min_lat := least(coalesce(min_lat, lat), lat);
+        min_lon := least(coalesce(min_lon, lon), lon);
+        max_lat := greatest(coalesce(max_lat, lat), lat);
+        max_lon := greatest(coalesce(max_lon, lon), lon);
+      end if;
+    end loop;
+
+    start_p := points->0;
+    middle_p := points->(((points_len - 1) / 2)::int);
+    end_p := points->(points_len - 1);
+    preview_rows := '[]'::jsonb;
+    preview_step := greatest(1, ceil(points_len::numeric / 120)::int);
+
+    for p, ord in select value, ordinality::int from jsonb_array_elements(points) with ordinality
+    loop
+      if ord = 1 or ord = points_len or ((ord - 1) % preview_step = 0) then
+        preview_rows := preview_rows || jsonb_build_array(jsonb_build_object(
+          'lat', (p->>0)::double precision,
+          'lon', (p->>1)::double precision
+        ));
+      end if;
+    end loop;
+
+    track_rows := track_rows || jsonb_build_array(jsonb_build_object(
+      'index', idx,
+      'name', coalesce(nullif(track->>'name', ''), 'Track ' || (idx + 1)),
+      'color', track->>'color',
+      'pointCount', points_len,
+      'start', jsonb_build_object('lat', (start_p->>0)::double precision, 'lon', (start_p->>1)::double precision),
+      'middle', jsonb_build_object('lat', (middle_p->>0)::double precision, 'lon', (middle_p->>1)::double precision),
+      'end', jsonb_build_object('lat', (end_p->>0)::double precision, 'lon', (end_p->>1)::double precision),
+      'preview', preview_rows
+    ));
+
+    idx := idx + 1;
+  end loop;
+
+  return jsonb_build_object(
+    'version', 2,
+    'trackCount', jsonb_array_length(track_rows),
+    'waypointCount', case when jsonb_typeof(waypoints_json) = 'array' then jsonb_array_length(waypoints_json) else 0 end,
+    'bounds', case when min_lat is null then null else jsonb_build_object(
+      'minLat', min_lat,
+      'minLon', min_lon,
+      'maxLat', max_lat,
+      'maxLon', max_lon
+    ) end,
+    'tracks', track_rows
+  );
+end;
+$$;
+
+update public.tours
+set route_metadata = public.build_route_metadata(gpx_route)
+where gpx_route is not null;
+
+create or replace function public.get_home_badges(
+  p_tour_ids uuid[],
+  p_chat_seen jsonb default '{}'::jsonb,
+  p_changelog_seen jsonb default '{}'::jsonb
+)
+returns table (
+  tour_id uuid,
+  chat_count bigint,
+  changelog_count bigint
+)
+language sql
+stable
+as $$
+  with requested as (
+    select unnest(p_tour_ids) as tour_id
+  ),
+  chat_counts as (
+    select m.tour_id, count(*)::bigint as count
+    from public.messages m
+    join requested r on r.tour_id = m.tour_id
+    where m.user_id <> auth.uid()
+      and m.created_at > coalesce(
+        nullif(p_chat_seen ->> m.tour_id::text, '')::timestamptz,
+        '-infinity'::timestamptz
+      )
+    group by m.tour_id
+  ),
+  log_counts as (
+    select l.tour_id, count(*)::bigint as count
+    from public.change_log l
+    join requested r on r.tour_id = l.tour_id
+    where l.user_id <> auth.uid()
+      and l.created_at > coalesce(
+        nullif(p_changelog_seen ->> l.tour_id::text, '')::timestamptz,
+        '-infinity'::timestamptz
+      )
+    group by l.tour_id
+  )
+  select
+    r.tour_id,
+    coalesce(c.count, 0)::bigint as chat_count,
+    coalesce(l.count, 0)::bigint as changelog_count
+  from requested r
+  left join chat_counts c on c.tour_id = r.tour_id
+  left join log_counts l on l.tour_id = r.tour_id;
+$$;


### PR DESCRIPTION
## Summary
- load tour detail without full GPX and fetch gpx_route only for the real map/download path
- add route preview points to route_metadata so overview and planning maps can render from small metadata
- limit initial chat/log payloads and bundle home badge counts through one RPC

## Database
- Applied remote migration: 20260508194842_route_preview_and_badge_rpc.sql

## Validation
- node --check js/utils.js
- node --check js/api.js
- node --check js/app.js
- node --check js/events.js
- node --check js/render.js
- node --check js/state.js
- supabase db push --dry-run