### PR TITLE
Lazy load full GPX maps

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -29,6 +29,32 @@ const TOUR_MESSAGE_SELECT = 'id,tour_id,user_id,username,text,created_at';
 const TOUR_CHANGELOG_SELECT = 'id,tour_id,user_id,username,field,old_value,new_value,created_at';
 const TOUR_INITIAL_LIMIT = 50;
 
+function _cachedRouteFields(tourId) {
+  if (!tourId) return null;
+  const sources = [
+    state.currentTour,
+    ...(state.tours || []),
+    ...(state.communityToursGpx || []),
+  ];
+  return sources.find(t => t?.id === tourId && t.gpx_route) || null;
+}
+
+function _preserveCachedRoute(tour) {
+  const cached = _cachedRouteFields(tour?.id);
+  if (!tour || !cached) return tour;
+  return {
+    ...tour,
+    gpx_route: cached.gpx_route,
+    route_metadata: tour.route_metadata || cached.route_metadata,
+    surface_analysis: tour.surface_analysis || cached.surface_analysis,
+    surface_display: tour.surface_display || cached.surface_display,
+  };
+}
+
+function _preserveCachedRoutes(tours) {
+  return (tours || []).map(_preserveCachedRoute);
+}
+
 /* ----------------------------------------------------------
    User seen-state (badges / banners)
    ---------------------------------------------------------- */
@@ -196,7 +222,7 @@ async function loadHomeData() {
     .eq('community_id', cid)
     .order('date', { ascending: true });
 
-  state.tours = toursRes.data || [];
+  state.tours = _preserveCachedRoutes(toursRes.data || []);
   if (!state.calMonth) state.calMonth = new Date();
 
   if (!state.tours.length) {
@@ -297,7 +323,7 @@ async function loadTourData(tourId) {
     sb.from('change_log').select(TOUR_CHANGELOG_SELECT).eq('tour_id', tourId).order('created_at', { ascending: false }).limit(TOUR_INITIAL_LIMIT),
   ]);
 
-  state.currentTour    = tourRes.data;
+  state.currentTour    = _preserveCachedRoute(tourRes.data);
   state.tourMessages   = (msgsRes.data || []).sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
   state.tourPlanDates  = datesRes.data     || [];
   state.tourChangelog  = changelogRes.data || [];
@@ -1137,7 +1163,7 @@ async function loadPlanningData() {
       .order('created_at', { ascending: false }),
   ]);
 
-  state.tours = tours || [];
+  state.tours = _preserveCachedRoutes(tours || []);
   state._loadedPlanningForCid = cid;
 
   state.communityMessages  = msgs || [];
@@ -1181,7 +1207,7 @@ async function loadPlanningMapRoutes() {
     .not('route_metadata', 'is', null)
     .order('date', { ascending: true });
 
-  state.communityToursGpx = data || [];
+  state.communityToursGpx = _preserveCachedRoutes(data || []);
   state._loadedPlanMapRoutesCid = cid;
   state.communityToursGpx.forEach(t => {
     if (state.planMapVisible[t.id] === undefined) state.planMapVisible[t.id] = true;
@@ -1198,6 +1224,7 @@ async function loadTourRouteGeometry(tourId) {
 
   const mergeRouteFields = t => t?.id === tourId ? { ...t, ...data } : t;
   state.tours = (state.tours || []).map(mergeRouteFields);
+  state.communityToursGpx = (state.communityToursGpx || []).map(mergeRouteFields);
   if (state.currentTour?.id === tourId) Object.assign(state.currentTour, data);
   return data;
 }

--- a/js/events.js
+++ b/js/events.js
@@ -791,7 +791,6 @@ function attachEvents() {
       const tab = card.dataset.goTab;
       if (!tab) return;
       state.currentTab = tab;
-      if (tab === 'map')       await ensureCurrentTourRouteLoaded();
       if (tab === 'chat')      await loadMessages();
       if (tab === 'changelog') await loadChangelog();
       if (tab === 'info' && state.tabBadges.info?.length) {
@@ -808,7 +807,6 @@ function attachEvents() {
   document.querySelectorAll('.tab-btn:not(.plan-tab-btn)').forEach(btn => {
     btn.addEventListener('click', async () => {
       state.currentTab = btn.dataset.tab;
-      if (state.currentTab === 'map')       await ensureCurrentTourRouteLoaded();
       if (state.currentTab === 'chat')      await loadMessages();
       if (state.currentTab === 'changelog') await loadChangelog();
 
@@ -859,7 +857,6 @@ function afterTabRender() {
         const tab = card.dataset.goTab;
         if (!tab) return;
         state.currentTab = tab;
-        if (tab === 'map')       await ensureCurrentTourRouteLoaded();
         if (tab === 'chat')      await loadMessages();
         if (tab === 'changelog') await loadChangelog();
         if (tab === 'info' && state.tabBadges.info?.length) {
@@ -877,13 +874,10 @@ function afterTabRender() {
   }
   if (state.currentTab === 'map') {
     setTimeout(() => {
-      ensureCurrentTourRouteLoaded().then(() => {
-        const tc = document.getElementById('tab-content');
-        if (tc && state.currentTour && state.currentTab === 'map') tc.innerHTML = renderTab(state.currentTour);
-        initMap(state.currentTour);
-        attachMapEvents();
-        attachSidebarEvents();
-      });
+      initMap(state.currentTour);
+      attachMapEvents();
+      attachSidebarEvents();
+      attachLazyFullRouteOnZoom();
     }, 80);
   }
   if (state.currentTab === 'chat') {
@@ -1206,6 +1200,46 @@ function attachMapEvents() {
       if (btn) delete btn.dataset.busy;
     }
   });
+}
+
+function attachLazyFullRouteOnZoom() {
+  if (!mapInstance || state.currentTour?.gpx_route || !state.currentTour?.route_metadata) return;
+  if (mapInstance._motorouteLazyRouteAttached) return;
+  const activeMap = mapInstance;
+  activeMap._motorouteLazyRouteAttached = true;
+  activeMap._motorouteZoomStart = activeMap.getZoom?.() || 0;
+  activeMap.on('zoomstart', () => {
+    activeMap._motorouteZoomStart = activeMap.getZoom?.() || 0;
+  });
+
+  const loadFullRoute = async () => {
+    if (mapInstance !== activeMap) return;
+    if (state.currentTour?.gpx_route || activeMap._motorouteFullRouteLoading) return;
+    if ((activeMap.getZoom?.() || 0) <= (activeMap._motorouteZoomStart || 0)) return;
+    activeMap._motorouteFullRouteLoading = true;
+    const restoreCenter = activeMap.getCenter?.();
+    const restoreZoom = activeMap.getZoom?.();
+    try {
+      await ensureCurrentTourRouteLoaded();
+      if (!state.currentTour?.gpx_route || state.currentTab !== 'map') return;
+      const tc = document.getElementById('tab-content');
+      if (tc) tc.innerHTML = renderTab(state.currentTour);
+      setTimeout(() => {
+        initMap(state.currentTour);
+        if (restoreCenter && Number.isFinite(restoreZoom)) {
+          mapInstance?.setView(restoreCenter, restoreZoom, { animate: false });
+        }
+        attachMapEvents();
+        attachSidebarEvents();
+      }, 40);
+    } catch (e) {
+      console.warn('[map lazy gpx]', e);
+      toast('Volle Route konnte nicht geladen werden.', 'error');
+      activeMap._motorouteFullRouteLoading = false;
+    }
+  };
+
+  activeMap.on('zoomend', loadFullRoute);
 }
 
 /* ----------------------------------------------------------
@@ -1784,8 +1818,9 @@ function attachPlanningContentEvents() {
 
 let _planMapInstance = null;
 let _planMapLayers   = [];
+const PLAN_FULL_ROUTE_ZOOM = 11;
 
-function _initPlanMap() {
+function _initPlanMap(restoreView = null) {
   const el = document.getElementById('plan-map');
   if (!el) return;
 
@@ -1840,6 +1875,10 @@ function _initPlanMap() {
     const combined = allBounds.reduce((acc, b) => acc.extend(b));
     _planMapInstance.fitBounds(combined, { padding: [30, 30] });
   }
+  if (restoreView?.center && Number.isFinite(restoreView.zoom)) {
+    _planMapInstance.setView(restoreView.center, restoreView.zoom, { animate: false });
+  }
+  attachLazyPlanRoutesOnZoom();
 }
 
 function _updatePlanMapLayers() {
@@ -1854,6 +1893,48 @@ function _updatePlanMapLayers() {
     }
   });
   _planMapInstance?.invalidateSize();
+}
+
+function attachLazyPlanRoutesOnZoom() {
+  if (!_planMapInstance) return;
+  if (_planMapInstance._motorouteLazyRouteAttached) return;
+
+  const activeMap = _planMapInstance;
+  activeMap._motorouteLazyRouteAttached = true;
+  activeMap._motorouteZoomStart = activeMap.getZoom?.() || 0;
+  activeMap.on('zoomstart', () => {
+    activeMap._motorouteZoomStart = activeMap.getZoom?.() || 0;
+  });
+
+  const loadVisibleFullRoutes = async () => {
+    if (_planMapInstance !== activeMap) return;
+    if (activeMap._motorouteFullRouteLoading) return;
+    if ((activeMap.getZoom?.() || 0) <= (activeMap._motorouteZoomStart || 0)) return;
+    if ((activeMap.getZoom?.() || 0) < PLAN_FULL_ROUTE_ZOOM) return;
+
+    const routeIds = (state.communityToursGpx || [])
+      .filter(t => state.planMapVisible[t.id] !== false)
+      .filter(t => !t.gpx_route && t.route_metadata)
+      .map(t => t.id);
+    if (!routeIds.length) return;
+
+    activeMap._motorouteFullRouteLoading = true;
+    const restoreView = {
+      center: activeMap.getCenter?.(),
+      zoom: activeMap.getZoom?.(),
+    };
+    try {
+      await Promise.all(routeIds.map(id => loadTourRouteGeometry(id)));
+      if (state.view !== 'planning' || state.planningTab !== 'map') return;
+      _initPlanMap(restoreView);
+    } catch (e) {
+      console.warn('[plan map lazy gpx]', e);
+      toast('Volle Routen konnten nicht geladen werden.', 'error');
+      activeMap._motorouteFullRouteLoading = false;
+    }
+  };
+
+  activeMap.on('zoomend', loadVisibleFullRoutes);
 }
 
 function _scrollPlanChat() {

--- a/js/map.js
+++ b/js/map.js
@@ -344,7 +344,8 @@ function initMap(tour) {
     maxZoom: 19,
   }).addTo(mapInstance);
 
-  const data = normalizeGPXRoute(tour.gpx_route);
+  const data = normalizeGPXRoute(tour.gpx_route)
+    || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(tour.route_metadata) : null);
   if (data) drawGPX(data);
 }
 

--- a/js/render.js
+++ b/js/render.js
@@ -1470,11 +1470,15 @@ function renderTourOverview(tour) {
    ---------------------------------------------------------- */
 
 function renderMapTab(tour) {
-  const gpxData = normalizeGPXRoute(tour.gpx_route);
+  const isPreview = !tour.gpx_route && !!tour.route_metadata;
+  const gpxData = normalizeGPXRoute(tour.gpx_route)
+    || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(tour.route_metadata) : null);
   const isAdmin = isCurrentUserAdmin();
   const hasTracks = gpxData?.tracks?.length > 0;
-  const hasWaypoints = gpxData?.waypoints?.length > 0;
+  const hasWaypoints = !isPreview && gpxData?.waypoints?.length > 0;
   const hasAny = hasTracks || hasWaypoints;
+  const trackCount = tour.route_metadata?.trackCount || gpxData?.tracks?.length || 0;
+  const waypointCount = tour.route_metadata?.waypointCount || gpxData?.waypoints?.length || 0;
 
   // Build sidebar track list
   let sidebarHtml = '';
@@ -1492,7 +1496,7 @@ function renderMapTab(tour) {
         </div>`;
       }).join('');
       sidebarHtml += `<div class="map-sidebar-section">
-        <div class="map-sidebar-title">Tracks (${gpxData.tracks.length})</div>
+        <div class="map-sidebar-title">Tracks (${trackCount})${isPreview ? '<span style="color:var(--muted);font-size:10px;margin-left:6px">Preview</span>' : ''}</div>
         ${tracksHtml}
         <div class="map-sidebar-item map-sidebar-reset" id="reset-highlight" style="margin-top:6px">
           <span style="font-size:13px">↩</span>
@@ -1515,6 +1519,12 @@ function renderMapTab(tour) {
           <button id="toggle-waypoints" class="map-sidebar-toggle" title="Wegpunkte ein-/ausblenden">👁 Alle</button>
         </div>
         ${wpsHtml}
+      </div>`;
+    }
+    if (isPreview && waypointCount > 0) {
+      sidebarHtml += `<div class="map-sidebar-section">
+        <div class="map-sidebar-title">Wegpunkte (${waypointCount})</div>
+        <div class="map-sidebar-empty">Wegpunkte werden beim Reinzoomen geladen.</div>
       </div>`;
     }
 
@@ -1551,8 +1561,8 @@ function renderMapTab(tour) {
     </div>
     <div class="map-info">
       ${hasAny
-        ? `<span>📍 ${gpxData.tracks.length} Track${gpxData.tracks.length !== 1 ? 's' : ''}</span>
-           ${hasWaypoints ? `<span>🚩 ${gpxData.waypoints.length} Wegpunkt${gpxData.waypoints.length !== 1 ? 'e' : ''}</span>` : ''}`
+        ? `<span>📍 ${trackCount} Track${trackCount !== 1 ? 's' : ''}${isPreview ? ' · Preview' : ''}</span>
+           ${waypointCount ? `<span>🚩 ${waypointCount} Wegpunkt${waypointCount !== 1 ? 'e' : ''}${isPreview ? ' · bei Zoom' : ''}</span>` : ''}`
         : `<span>${isAdmin ? 'Keine Route — GPX-Datei hochladen' : 'Admin hat noch keine Route hochgeladen'}</span>`}
     </div>
   </div>


### PR DESCRIPTION
## Änderungen
- Karten-Tab öffnet zuerst mit Route-Preview aus den Metadaten und lädt die volle GPX erst beim ersten Zoom-In nach.
- Planungskarte nutzt ebenfalls Preview-Daten und lädt volle GPX erst ab Zoom-Level 11 für sichtbare Touren.
- Bereits lokal geladene GPX-Daten bleiben beim erneuten Laden von Home-, Tour- und Planungsdaten im Cache erhalten.
- Nach dem GPX-Nachladen bleiben Zoom und Kartenposition erhalten.

## Warum
Das reduziert Supabase PostgREST-Egress und Disk-IO, ohne die Kartenansicht dauerhaft auf Preview-Daten zu beschränken.

## Checks
- node --check js/api.js
- node --check js/events.js
- node --check js/map.js
- node --check js/render.js