### PR TITLE
Log community member leave/kick to community_changelog

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1174,6 +1174,10 @@ async function leaveCommunity() {
     .eq('community_id', state.currentCommunityId)
     .eq('user_id', state.currentUser.id);
   if (error) throw new Error(error.message);
+  // Log vor dem State-Update, damit currentCommunityId noch gesetzt ist.
+  // Ohne diesen Log-Eintrag bleibt das Verlassen der Community im normalen
+  // Changelog unsichtbar (Audit-Tabelle hat es zwar, aber Admins sehen sie nicht).
+  await logCommunityChange('Mitglied verlassen', state.currentUser.username, '');
   state.myCommunityIds.delete(state.currentCommunityId);
 }
 
@@ -1261,6 +1265,8 @@ async function removeCommunityMember(userId) {
     .eq('community_id', state.currentCommunityId)
     .eq('user_id', userId);
   if (error) throw new Error(error.message);
+  const username = state.profileCache[userId] || userId;
+  await logCommunityChange('Mitglied entfernt', username, '');
 }
 
 async function createCommunity(name, password) {


### PR DESCRIPTION
## Summary

Folge-Fix zu PR #112: `leaveCommunity()` und `removeCommunityMember()` haben bisher den `community_members`-Eintrag still gelöscht — weder `change_log` noch `community_changelog` haben einen Eintrag bekommen.

Damit ließ sich nicht nachvollziehen, wer ein Mitglied entfernt hatte (siehe Tom-Vorfall: 8× Tour-Kick im Log, aber kein Community-Eintrag, obwohl er aus der Community raus war).

Beide Funktionen schreiben jetzt einen Eintrag in `community_changelog`:
- `leaveCommunity()` → `'Mitglied verlassen'`
- `removeCommunityMember()` → `'Mitglied entfernt'`

Die zusätzliche `community_member_audit`-Tabelle (aus PR #112) bleibt parallel scharf — Belt-and-Suspenders. Der Changelog-Eintrag macht es im Log-Tab sofort sichtbar; die Audit-Tabelle erfasst zusätzlich auch direkte DB-Eingriffe.

## Test plan

- [ ] Community-Mitglied entfernen (als Admin) → Log-Tab zeigt "Mitglied entfernt: <Name>"
- [ ] Eigene Community verlassen → in der Community davor noch im Log-Tab nachschauen, dort steht "Mitglied verlassen: <eigener Name>"

🤖 Generated with [Claude Code](https://claude.com/claude-code)