### PR TITLE
Persist tour-detail data so offline cold start renders the tour

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1456,7 +1456,20 @@ async function init() {
   const restoredAtBoot = restoreState() && !!state.currentUser;
   if (restoredAtBoot && !navigator.onLine) {
     console.log('[init] Boot mit gespeichertem State');
-    state.view = state.currentCommunityId ? 'community-home' : 'communities';
+    // Wenn der User zuletzt eine Tour offen hatte UND wir die zugehörigen
+    // Daten gecached haben, direkt dorthin booten — sonst sieht er beim
+    // Offline-Cold-Start nie wieder Mitglieder/Chat/Log/Karte. Voraussetzung:
+    // currentTourId, currentTour mit gleicher ID und persistierte Tour-Listen.
+    const canBootToTour = state.currentTourId
+      && state.currentTour?.id === state.currentTourId
+      && state.currentCommunityId;
+    if (canBootToTour) {
+      state.view = 'tour';
+    } else if (state.currentCommunityId) {
+      state.view = 'community-home';
+    } else {
+      state.view = 'communities';
+    }
     render();
     return;
   } else if (!navigator.onLine) {

--- a/js/state.js
+++ b/js/state.js
@@ -77,7 +77,7 @@ const state = {
    offline with previously cached data.
    ---------------------------------------------------------- */
 const STATE_STORAGE_KEY = 'motoroute_state_v1';
-const STATE_SCHEMA_VERSION = 6;
+const STATE_SCHEMA_VERSION = 7;
 const STATE_APP_VERSION = (typeof APP_VERSION !== 'undefined' && APP_VERSION) ? APP_VERSION : 'dev';
 const STATE_MAX_AGE_MS  = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -104,6 +104,15 @@ function persistState() {
       communityChangelog: state.communityChangelog,
       communityPolls:     state.communityPolls,
       communityMessages:  state.communityMessages,
+      // Tour-Detail-Daten persistieren, damit ein Offline-Cold-Start die
+      // zuletzt geöffnete Tour vollständig anzeigen kann (Mitglieder, Chat,
+      // Plan-Termine, Log, Media). Die GPX-Geometrie liegt separat in IndexedDB
+      // (siehe gpx-cache.js). Wetter wird live von open-meteo geladen und ist
+      // offline bewusst nicht verfügbar.
+      tourMembers:        state.tourMembers,
+      tourMessages:       state.tourMessages,
+      tourChangelog:      state.tourChangelog,
+      tourMedia:          state.tourMedia,
       tourPlanDates:      state.tourPlanDates,
       profileCache:       state.profileCache,
       memberCounts:       state.memberCounts,


### PR DESCRIPTION
## Symptom

Beim Offline-Cold-Start auf einer zuvor geöffneten Tour sieht der User weder Tour-Infos noch Mitglieder, Chat, Log, Karte oder Media — alles ist leer, obwohl die Daten beim letzten Online-Besuch im State waren.

## Zwei Ursachen

### 1) `persistState()` fehlt Tour-Detail-Listen
`js/state.js` persistierte zwar `currentTour` (ohne `gpx_route`), aber **nicht** die Geschwister-Listen:
- `tourMembers` — Mitglieder & Avatare
- `tourMessages` — Chat (max 50 Einträge dank TOUR_INITIAL_LIMIT)
- `tourChangelog` — Tour-Log (max 50)
- `tourMedia` — Media-Metadaten

Beim Cold-Restore standen diese auf ihrem Default `[]`. Ergebnis: Tour-Tabs leer.

`tourPlanDates` war bereits persistiert; `gpx_route` lebt in IndexedDB (`gpx-cache.js`); Wetter ist live von open-meteo und offline bewusst nicht verfügbar.

Schema-Version auf **v7** angehoben — alte v6-Snapshots werden bei nächstem Start invalidiert.

### 2) Offline-Boot-Pfad ignorierte die Tour
`js/app.js` setzte beim Offline-Boot **immer** `state.view = state.currentCommunityId ? 'community-home' : 'communities'` — selbst wenn der User zuletzt auf der Tour-View war. Selbst mit (1) gefixt würde der User die Tour nie wieder sehen.

Neuer Guard: Wenn `currentTourId`, `currentTour.id` und `currentCommunityId` konsistent sind, booten wir direkt zu `'tour'`. Fallback bleibt unverändert.

## Test plan

- [ ] App online öffnen, Tour öffnen, Mitglieder/Chat/Log/Media laden
- [ ] App schließen → Flugmodus → App öffnen → landet auf Tour-View mit allen Daten sichtbar
- [ ] Karten-Tab auf Tour-View offline → GPX-Preview-Polyline (aus route_metadata) und volle Geometrie aus IndexedDB
- [ ] Wetter-Tab offline → zeigt "wird geladen…" oder leeres State (Live-Endpoint, bewusst nicht gecached)
- [ ] Online wieder, Cold Start → SWR-Fast-Path: Tour wird sofort aus persisted State gerendert, dann live aktualisiert
- [ ] Erste Aktivierung nach Deploy: Schema v6→v7 invalidiert alten State (User landet einmal auf Communities-Liste, danach normal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)