### PR TITLE
Fix dark map on offline cold-start; revert tour auto-boot

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1456,20 +1456,7 @@ async function init() {
   const restoredAtBoot = restoreState() && !!state.currentUser;
   if (restoredAtBoot && !navigator.onLine) {
     console.log('[init] Boot mit gespeichertem State');
-    // Wenn der User zuletzt eine Tour offen hatte UND wir die zugehörigen
-    // Daten gecached haben, direkt dorthin booten — sonst sieht er beim
-    // Offline-Cold-Start nie wieder Mitglieder/Chat/Log/Karte. Voraussetzung:
-    // currentTourId, currentTour mit gleicher ID und persistierte Tour-Listen.
-    const canBootToTour = state.currentTourId
-      && state.currentTour?.id === state.currentTourId
-      && state.currentCommunityId;
-    if (canBootToTour) {
-      state.view = 'tour';
-    } else if (state.currentCommunityId) {
-      state.view = 'community-home';
-    } else {
-      state.view = 'communities';
-    }
+    state.view = state.currentCommunityId ? 'community-home' : 'communities';
     render();
     return;
   } else if (!navigator.onLine) {

--- a/js/map.js
+++ b/js/map.js
@@ -337,15 +337,40 @@ function initMap(tour) {
     endMarker        = null;
   }
 
-  mapInstance = L.map('map', { center: [48.2, 9.5], zoom: 7, zoomControl: true });
+  // Daten zuerst auflösen, damit wir den initialen View direkt auf die Tour
+  // zentrieren können. Andernfalls würde Leaflet zuerst Tiles für den Default
+  // (zoom 7, Mitte Deutschland) anfragen — die sind im Offline-Fall fast nie
+  // gecacht und der User sieht eine "dunkle" Karte, bis drawGPX→fitBounds
+  // greift. Mit korrektem Initial-Center werden direkt die gecachten Tour-
+  // Tiles geholt.
+  const data = normalizeGPXRoute(tour.gpx_route)
+    || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(tour.route_metadata) : null);
+
+  let initCenter = [48.2, 9.5];
+  let initZoom   = 7;
+  let initBounds = null;
+  if (data?.tracks?.length) {
+    const allPoints = data.tracks.flatMap(t => t.points || []);
+    if (allPoints.length) {
+      initBounds = L.latLngBounds(allPoints);
+      const c = initBounds.getCenter();
+      initCenter = [c.lat, c.lng];
+      initZoom   = 11; // grobe Schätzung; fitBounds verfeinert gleich
+    }
+  }
+
+  mapInstance = L.map('map', { center: initCenter, zoom: initZoom, zoomControl: true });
+  if (initBounds) {
+    // Bounds direkt vor dem tileLayer setzen — so kennt Leaflet die richtige
+    // Größe/zoom-Stufe schon beim ersten Tile-Request.
+    mapInstance.fitBounds(initBounds, { padding: [40, 40], animate: false });
+  }
 
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     maxZoom: 19,
   }).addTo(mapInstance);
 
-  const data = normalizeGPXRoute(tour.gpx_route)
-    || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(tour.route_metadata) : null);
   if (data) drawGPX(data);
 }
 

--- a/sw.js
+++ b/sw.js
@@ -201,11 +201,18 @@ self.addEventListener('fetch', event => {
         return response;
       }).catch(() => {
         // Offline + nicht gecacht → leere aber gültige PNG-Antwort
-        // (Leaflet zeigt graue Tile statt kaputtem Bild-Icon)
-        return new Response(
-          atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='),
-          { status: 200, headers: { 'Content-Type': 'image/png' } }
-        );
+        // (Leaflet zeigt graue Tile statt kaputtem Bild-Icon).
+        // WICHTIG: atob() liefert einen Binary-String — als String an Response
+        // übergeben würde der als UTF-8 enkodiert und das PNG zerstört. Deshalb
+        // explizit in Uint8Array umwandeln, damit echte Bytes ausgehen.
+        const b64   = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+        const bin   = atob(b64);
+        const bytes = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        return new Response(bytes, {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        });
       })
     );
     return;


### PR DESCRIPTION
## Summary

Drei zusammenhängende Fixes nach Feedback zu PR #115:

### 1) Offline-Boot zurück auf community-home
Die in PR #115 hinzugefügte „Boot-direkt-zur-Tour"-Logik in `js/app.js` wird zurückgenommen. Beim Offline-Cold-Start landet der User wieder auf `community-home` (oder `communities`), unabhängig davon was er zuletzt offen hatte. Die Tour-Detail-Daten bleiben **weiterhin** in `persistState` (`tourMembers`, `tourMessages`, `tourChangelog`, `tourMedia`) — sie werden für den SWR-Fast-Path gebraucht sobald der User die Tour wieder öffnet.

### 2) SW Tile-Fallback PNG repariert (`sw.js`)
Der Offline-Tile-Fallback war mit einem subtilen Bug behaftet:
```js
return new Response(atob('iVBORw0KGgo…'), { headers: { 'Content-Type': 'image/png' }});
```
`atob()` liefert einen Binary-String. Wenn der direkt als Response-Body übergeben wird, encoded der Browser ihn als UTF-8 — alle Bytes >127 werden zu Zwei-Byte-Sequenzen, das PNG ist zerstört. Browser zeigt ein Broken-Image-Icon statt der gewünschten transparenten Grau-Kachel.

Fix: explizit in `Uint8Array` konvertieren, damit echte Bytes ausgehen.

### 3) Map startet direkt im Tour-Bereich (`js/map.js`)
**Hauptursache der „dunklen" Karte beim Offline-Cold-Start.**

`initMap` instanziierte Leaflet mit `center: [48.2, 9.5], zoom: 7` (Mitte Deutschland) und ließ erst `drawGPX` → `fitBounds` zur Tour zoomen. Beim Offline-User passiert dazwischen:
1. Leaflet feuert sofort Tile-Requests für **zoom 7 / Mitte-DE** ab
2. Diese Tiles sind im 500-Tile-Cache fast nie drin (User war dort nie zoomed-out)
3. SW Cache-Miss → Fallback (vor Fix 2: kaputtes PNG → Broken-Image-Container)
4. Auf dunklem Theme erscheint das als „schwarze" Karte
5. Erst dann zoomt `fitBounds` zur Tour, wo Tiles tatsächlich gecacht sind

Neue Logik:
- GPX/Preview-Daten werden **vor** der Map-Instanziierung aufgelöst
- Aus den Track-Punkten wird `L.latLngBounds` berechnet
- `L.map(...)` startet direkt mit dem berechneten `center + zoom`
- `fitBounds(initBounds, { animate: false })` läuft VOR `tileLayer.addTo()`
- Erst dann wird der TileLayer attached → erste Tile-Requests gehen direkt an den Tour-Bereich, der zu 99% im Cache liegt

Effekt: Karte zeigt sofort Tiles statt zu „blinken".

## Test plan

- [ ] Online: Tour öffnen, Map laden (Tiles cachen)
- [ ] App schließen, Flugmodus, App öffnen → landet auf community-home (nicht Tour)
- [ ] Tour aus Liste anklicken → Map-Tab → Karte zeigt sofort gecachte Tiles im Tour-Bereich
- [ ] Auf einen ungecachten Bereich panen → graue Tiles (echte transparente PNGs, kein Broken-Image)
- [ ] Online wieder, neue Tour ohne Cache öffnen → normale Default-View (zoom 7) wenn keine Bounds berechenbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)