### PR TITLE
Unblock offline tour navigation; harden map init

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -213,6 +213,19 @@ async function navigateTo(view, params = {}) {
   _navigating = true;
 
   try {
+    // Offline-Pre-Check: Wenn wir offline sind und auf eine Tour navigieren
+    // wollen, die nicht im persistierten State ist, gibt es keine Möglichkeit
+    // sie zu laden. Toast statt User in eine "Tour nicht gefunden"-Sackgasse
+    // navigieren zu lassen.
+    if (view === 'tour' && !navigator.onLine) {
+      const targetTourId = params.currentTourId || state.currentTourId;
+      if (targetTourId && state.currentTour?.id !== targetTourId) {
+        if (typeof toast === 'function') toast('Diese Tour ist offline nicht verfügbar', 'error');
+        _navigating = false;
+        return;
+      }
+    }
+
     // Tear down map when leaving the tour detail page
     if (mapInstance && view !== 'tour') destroyMap();
     // Tear down overview mini-map when leaving tour

--- a/js/map.js
+++ b/js/map.js
@@ -337,39 +337,55 @@ function initMap(tour) {
     endMarker        = null;
   }
 
-  // Daten zuerst auflösen, damit wir den initialen View direkt auf die Tour
-  // zentrieren können. Andernfalls würde Leaflet zuerst Tiles für den Default
-  // (zoom 7, Mitte Deutschland) anfragen — die sind im Offline-Fall fast nie
-  // gecacht und der User sieht eine "dunkle" Karte, bis drawGPX→fitBounds
-  // greift. Mit korrektem Initial-Center werden direkt die gecachten Tour-
-  // Tiles geholt.
+  // Daten + Bounds zuerst auflösen, damit wir den initialen View direkt auf
+  // die Tour zentrieren können. Andernfalls würde Leaflet zuerst Tiles für
+  // den Default (zoom 7, Mitte Deutschland) anfragen — die sind im Offline-
+  // Fall fast nie gecacht und der User sieht eine "dunkle" Karte, bis
+  // drawGPX→fitBounds greift.
   const data = normalizeGPXRoute(tour.gpx_route)
     || (typeof routeMetadataToPreviewRoute === 'function' ? routeMetadataToPreviewRoute(tour.route_metadata) : null);
 
+  // Initial-Bounds: bevorzugt aus route_metadata.bounds (immer vorhanden wenn
+  // GPX existiert, auch wenn preview leer ist), Fallback aus Track-Punkten.
+  let initBounds = null;
+  const rmBounds = tour.route_metadata?.bounds;
+  if (rmBounds
+      && Number.isFinite(rmBounds.minLat) && Number.isFinite(rmBounds.maxLat)
+      && Number.isFinite(rmBounds.minLon) && Number.isFinite(rmBounds.maxLon)) {
+    initBounds = L.latLngBounds(
+      [rmBounds.minLat, rmBounds.minLon],
+      [rmBounds.maxLat, rmBounds.maxLon]
+    );
+  } else if (data?.tracks?.length) {
+    const allPoints = data.tracks.flatMap(t => t.points || []);
+    if (allPoints.length) initBounds = L.latLngBounds(allPoints);
+  }
+
   let initCenter = [48.2, 9.5];
   let initZoom   = 7;
-  let initBounds = null;
-  if (data?.tracks?.length) {
-    const allPoints = data.tracks.flatMap(t => t.points || []);
-    if (allPoints.length) {
-      initBounds = L.latLngBounds(allPoints);
-      const c = initBounds.getCenter();
-      initCenter = [c.lat, c.lng];
-      initZoom   = 11; // grobe Schätzung; fitBounds verfeinert gleich
-    }
+  if (initBounds) {
+    const c = initBounds.getCenter();
+    initCenter = [c.lat, c.lng];
+    initZoom   = 12; // typisch für Tour-View; fitBounds verfeinert gleich
   }
 
   mapInstance = L.map('map', { center: initCenter, zoom: initZoom, zoomControl: true });
-  if (initBounds) {
-    // Bounds direkt vor dem tileLayer setzen — so kennt Leaflet die richtige
-    // Größe/zoom-Stufe schon beim ersten Tile-Request.
-    mapInstance.fitBounds(initBounds, { padding: [40, 40], animate: false });
-  }
 
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     maxZoom: 19,
   }).addTo(mapInstance);
+
+  // Container-Größe an Leaflet weitergeben, falls der Tab-Wechsel die CSS-
+  // Layout-Pass noch nicht durch hatte. Ohne invalidateSize bleibt die Karte
+  // gelegentlich auf 0×0 und zeigt nichts an.
+  requestAnimationFrame(() => {
+    if (!mapInstance) return;
+    mapInstance.invalidateSize(false);
+    if (initBounds) {
+      mapInstance.fitBounds(initBounds, { padding: [40, 40], animate: false });
+    }
+  });
 
   if (data) drawGPX(data);
 }

--- a/js/render.js
+++ b/js/render.js
@@ -312,7 +312,16 @@ function renderPageHeader() {
       break;
 
     case 'tour': {
-      if (!tour) return '';
+      if (!tour) {
+        // Tour nicht im State (z.B. offline + Cache-Miss): trotzdem Back-Button
+        // rendern, sonst sitzt der User in einer Sackgasse fest.
+        backBtn = `<button class="btn-icon-back" id="back-home" title="Zurück" aria-label="Zurück">${backIcon}</button>`;
+        return `${backBtn}
+          <div class="page-header-titleblock">
+            <div class="page-header-eyebrow">${esc(community?.name || 'Community')}</div>
+            <div class="page-header-title">Tour</div>
+          </div>`;
+      }
       const canLeave = tour.admin_id !== state.currentUser.id;
       // Date period
       const tStart = new Date(tour.date + 'T12:00:00');
@@ -1115,7 +1124,16 @@ function renderJoin() {
 
 function renderTour() {
   const tour = state.currentTour;
-  if (!tour) return '<div style="padding:40px;color:var(--muted)">Tour nicht gefunden.</div>';
+  if (!tour) {
+    const isOffline = !navigator.onLine;
+    const msg = isOffline
+      ? 'Diese Tour ist offline nicht verfügbar. Bitte gehe online oder kehre zur Community zurück.'
+      : 'Tour nicht gefunden.';
+    return `<div style="padding:40px;color:var(--muted);text-align:center">
+      <div style="margin-bottom:16px">${esc(msg)}</div>
+      <button class="btn btn-primary" id="back-home">Zurück zur Community</button>
+    </div>`;
+  }
 
   const tabs = [
     { id: 'overview',     label: '⊞' },


### PR DESCRIPTION
## Symptome (gemeldet nach PR #116)

1. **Sackgasse**: Offline auf eine **andere** (uncached) Tour klicken → "Tour nicht gefunden", kein Header, kein Back-Button → User gefangen.
2. **Dunkle Karte** beim Offline-Cold-Start auf der zuletzt geöffneten Tour, trotz korrekt geladener restlicher Tabs.

## Drei Fixes

### 1) `navigateTo` Offline-Pre-Check (`js/app.js`)
Bevor wir `view='tour'` wechseln und `loadTourData` losschicken: wenn offline UND `state.currentTour?.id !== targetTourId`, dann kann der Fetch nicht klappen und wir würden in der Sackgasse landen. Stattdessen Toast `Diese Tour ist offline nicht verfügbar` und Navigation abbrechen.

### 2) Tour-View Fallback-Rendering (`js/render.js`)
Falls wir doch ohne `currentTour` auf `view='tour'` landen (z.B. ältere Clients, edge cases):
- `renderPageHeader` rendert auch ohne tour einen funktionierenden Back-Button.
- `renderTour` zeigt eine klarere Offline-Meldung **plus** einen "Zurück zur Community"-Button.

### 3) Map-Init robuster (`js/map.js`)
Drei Verbesserungen kombiniert, eine davon ist sehr wahrscheinlich die wirkliche Ursache der "dunklen Karte":

- **`route_metadata.bounds` direkt nutzen** statt aus Preview-Punkten neu zu rechnen. Bounds sind immer vorhanden wenn die Tour GPX hat — auch wenn `preview` durch ältere Daten leer ist.
- **Initial-Zoom 12 statt 11**, damit Leaflet's erste Tile-Anfrage direkt in dem Bereich landet, den der User offline schon mal angeschaut (und gecacht) hat.
- **`requestAnimationFrame` + `invalidateSize`** nach `L.map(...)`. **Das ist vermutlich der Schlüssel**: beim Tab-Wechsel kann der CSS-Layout-Pass noch nicht durch sein, der Map-Container hat dann 0×0 px, Leaflet rechnet einen falschen Zoom — Tiles laden für nirgendwo, Karte bleibt schwarz. Mit `invalidateSize` nach dem ersten Frame ist der Container garantiert vermessen.
- `fitBounds` ebenfalls in den RAF-Callback gezogen, damit es erst nach dem `invalidateSize` läuft.

## Test plan

- [ ] Offline + Cold Start → community-home → andere Tour anklicken → Toast "Tour ist offline nicht verfügbar", User bleibt auf Community
- [ ] Falls man trotzdem (z.B. via Deep-Link) auf Tour-View ohne Daten landet: Header + Back-Button da, klickbar, führt zurück zu Community
- [ ] Offline + Cold Start → community-home → letzte Tour öffnen → Map-Tab → Karte zeigt sofort gecachte Tiles im Tour-Bereich
- [ ] Online: kein Verhalten geändert, Map funktioniert wie bisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)