### PR TITLE
Force tile redraw on online comeback and after SW becomes ready

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -405,13 +405,24 @@ async function loadTourData(tourId) {
     sb.from('change_log').select(TOUR_CHANGELOG_SELECT).eq('tour_id', tourId).order('created_at', { ascending: false }).limit(TOUR_INITIAL_LIMIT),
   ]);
 
-  // Wenn die Haupt-Tour-Query transient fehlschlägt (Timeout, 401, offline) UND
-  // wir haben dieselbe Tour bereits im State → cached State behalten statt zu
-  // overwriten. PGRST116 (single() row not found) ist KEIN transienter Fehler —
-  // dann ist die Tour wirklich gelöscht und der State sollte sich aktualisieren.
-  if (_isTransientFetchError(tourRes) && state.currentTour?.id === tourId) {
-    console.warn('[loadTourData] transient error, keeping cached tour state', tourRes.error);
-    return;
+  // Wenn die Haupt-Tour-Query transient fehlschlägt (Timeout, 401, offline,
+  // iOS-Socket-Glitch nach Flugmodus etc.):
+  // - Selbe Tour im State → still cached State behalten.
+  // - Andere/keine Tour im State → ERROR werfen, sodass navigateTo den State
+  //   revertet und einen Retry-Toast zeigt. Sonst würde state.currentTour=null
+  //   gesetzt → Render zeigt fälschlich "Tour nicht gefunden", obwohl die
+  //   Tour existiert und nur die Verbindung gerade kaputt ist.
+  // PGRST116 (row not found) ist KEIN transienter Fehler — dann ist die Tour
+  // wirklich gelöscht und State darf aktualisiert werden.
+  if (_isTransientFetchError(tourRes)) {
+    if (state.currentTour?.id === tourId) {
+      console.warn('[loadTourData] transient error, keeping cached tour state', tourRes.error);
+      return;
+    }
+    console.warn('[loadTourData] transient error for new tour — surfacing', tourRes.error);
+    const err = new Error('Verbindung instabil — bitte erneut versuchen');
+    err.code = 'TRANSIENT_LOAD';
+    throw err;
   }
 
   state.currentTour = _preserveCachedRoute(tourRes.data);

--- a/js/app.js
+++ b/js/app.js
@@ -250,6 +250,18 @@ async function navigateTo(view, params = {}) {
       _planMapLayers   = [];
     }
 
+    // Snapshot vor State-Änderung — nötig für Revert wenn loadViewData transient
+    // fehlschlägt (iOS-Sockets nach Flugmodus, Timeout etc.). Ohne Revert würde
+    // der User auf einer kaputten Tour-View landen mit currentTourId der neuen
+    // Tour aber currentTour == null → "Tour nicht gefunden".
+    const _navSnapshot = {
+      view:               state.view,
+      currentTourId:      state.currentTourId,
+      currentTour:        state.currentTour,
+      currentCommunityId: state.currentCommunityId,
+      currentCommunity:   state.currentCommunity,
+    };
+
     // Merge any extra params into global state
     Object.assign(state, params);
 
@@ -282,10 +294,23 @@ async function navigateTo(view, params = {}) {
     }
 
     // Load data required for the target view
+    let transientLoadFailure = false;
     try {
       await _loadViewData(view);
     } catch (e) {
       console.error('[navigateTo] data fetch error:', e);
+      if (e?.code === 'TRANSIENT_LOAD') {
+        transientLoadFailure = true;
+      }
+    }
+
+    // Bei transientem Load-Fehler (z.B. iOS-Socket-Glitch nach Flugmodus):
+    // State-Snapshot zurückspielen, Toast zeigen, NICHT zur kaputten View
+    // navigieren. Der User bleibt da wo er war und kann es erneut versuchen.
+    if (transientLoadFailure) {
+      Object.assign(state, _navSnapshot);
+      if (typeof toast === 'function') toast('Verbindung instabil — bitte erneut versuchen', 'error');
+      return;
     }
 
     // Nach dem Laden neu rendern — bei SWR ist dies der "stille" Update-Render.

--- a/js/app.js
+++ b/js/app.js
@@ -503,8 +503,41 @@ function startForegroundRefresh() {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') refreshCurrentView({ force: true });
   });
-  window.addEventListener('online', () => refreshCurrentView({ force: true }));
+  window.addEventListener('online', () => {
+    // Wenn der User vorher offline war, hat Leaflet TileLayer die fehlgeschlagenen
+    // (oder leeren-PNG-) Tiles als "loaded" markiert und fragt sie nicht neu an.
+    // Beim Wiederkehren der Verbindung explizit redrawen, sonst bleibt die Karte
+    // dunkel bis der User pannt/zoomt.
+    _redrawAllMapTiles();
+    // Ebenso ggf. fehlende GPX-Geometrie laden, falls der User noch im Map-Tab
+    // ist und sie offline nicht gecached war.
+    if (state.view === 'tour' && state.currentTab === 'map' && typeof ensureCurrentTourRouteLoaded === 'function') {
+      ensureCurrentTourRouteLoaded().catch(() => {});
+    }
+    refreshCurrentView({ force: true });
+  });
   window.addEventListener('focus', () => refreshCurrentView({ force: true }));
+}
+
+/**
+ * Forciere TileLayer-Redraw auf allen aktiven Leaflet-Maps. Wird beim Online-
+ * Comeback aufgerufen — ohne das bleiben offline geladene leere PNGs für
+ * immer in der View hängen.
+ */
+function _redrawAllMapTiles() {
+  const maps = [];
+  if (typeof mapInstance !== 'undefined' && mapInstance) maps.push(mapInstance);
+  if (typeof window !== 'undefined' && window._tovMapInstance) maps.push(window._tovMapInstance);
+  if (typeof _planMapInstance !== 'undefined' && _planMapInstance) maps.push(_planMapInstance);
+  for (const m of maps) {
+    try {
+      m.eachLayer(layer => {
+        if (layer instanceof L.TileLayer && typeof layer.redraw === 'function') {
+          layer.redraw();
+        }
+      });
+    } catch (e) { /* non-fatal */ }
+  }
 }
 
 /* ----------------------------------------------------------

--- a/js/map.js
+++ b/js/map.js
@@ -371,7 +371,7 @@ function initMap(tour) {
 
   mapInstance = L.map('map', { center: initCenter, zoom: initZoom, zoomControl: true });
 
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  const tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     maxZoom: 19,
   }).addTo(mapInstance);
@@ -386,6 +386,21 @@ function initMap(tour) {
       mapInstance.fitBounds(initBounds, { padding: [40, 40], animate: false });
     }
   });
+
+  // PWA-Cold-Start-Race-Fallback: Wenn beim Mounten der Karte der Service
+  // Worker noch nicht die Kontrolle übernommen hat, gehen die ersten Tile-
+  // Requests am SW vorbei direkt ans Netzwerk — das schlägt offline fehl
+  // und die Tiles bleiben als "loaded" markiert (broken/empty), die Karte
+  // bleibt dunkel. Sobald der SW ready ist, alle Tiles neu zeichnen.
+  if ('serviceWorker' in navigator && navigator.serviceWorker.ready) {
+    navigator.serviceWorker.ready
+      .then(() => {
+        if (mapInstance && tileLayer && typeof tileLayer.redraw === 'function') {
+          tileLayer.redraw();
+        }
+      })
+      .catch(() => {});
+  }
 
   if (data) drawGPX(data);
 }


### PR DESCRIPTION
## Symptome (gemeldet nach PR #117)

1. **Cold-Start dunkle Karte**: Wenn die App komplett geschlossen war und offline neu gestartet wird, bleibt die Karte schwarz — auch für Tour-Bereiche, die der User vorher online angeschaut hatte.
2. **Online-Wiederkehr greift nicht**: Wenn die Verbindung zurückkommt, verschwindet zwar der Offline-Banner, aber Karte und uncached Tours laden trotzdem nicht. Erst ein App-Neustart hilft.

## Diagnose

Symptom 1+2 (Karte) haben dieselbe Wurzel: **Leaflet markiert fehlgeschlagene Tile-Requests als „loaded"** und fragt sie nie wieder an.

Symptom 2 (uncached Tours) liegt zusätzlich an iOS Safari nach Flugmodus: `navigator.onLine === true` wird sofort gesetzt, aber die Network-Sockets sind noch ein paar Sekunden kaputt — Fetches scheitern still, Loader bekommen `data: null`, App verhält sich wie offline.

## Fixes

### Commit 1 — Tile-Redraw (`js/app.js`, `js/map.js`)

**`online`-Handler erweitert**:
- `_redrawAllMapTiles()` — explizit `tileLayer.redraw()` für alle aktiven Maps (Tour-Karte, Planungs-Karte, Overview-Mini-Map)
- `ensureCurrentTourRouteLoaded()` — wenn auf dem Map-Tab und GPX offline nicht ladbar war
- weiterhin `refreshCurrentView({ force: true })` für API-Daten

**Cold-Start-Race-Fallback in `initMap`**:
```js
navigator.serviceWorker.ready.then(() => tileLayer.redraw());
```
Sobald der SW garantiert die Kontrolle hat, werden alle Tiles neu angefordert. Bei Warm-Starts ist das ein No-Op.

### Commit 2 — Transient Load-Failure mit Retry-Toast (`js/api.js`, `js/app.js`)

**`loadTourData`** unterscheidet zwei Transient-Fälle:
- Selbe Tour im State → cached State still behalten (bisheriges Verhalten)
- Andere/keine Tour im State → `TRANSIENT_LOAD` werfen statt `null` in state.currentTour zu schreiben

PGRST116 (row not found) bleibt unverändert das echte „gelöscht"-Signal.

**`navigateTo`** macht einen State-Snapshot vor `Object.assign(state, params)`. Wenn `_loadViewData` mit `TRANSIENT_LOAD` rauskommt: Snapshot zurückspielen, Toast „Verbindung instabil — bitte erneut versuchen", return ohne Render. User bleibt wo er war.

## Was offen bleibt

iOS-PWAs nach Flugmodus haben den bekannten Socket-Glitch — den können wir nicht direkt reparieren. Aber statt Lockout sehen User jetzt einen klaren Hinweis und können retry'en. iOS erholt sich meist in wenigen Sekunden.

## Test plan

- [ ] Online: Tour öffnen, Map laden (Tiles cachen), App schließen
- [ ] Flugmodus, App öffnen → community-home → Tour öffnen → Map-Tab → Tiles erscheinen (auch bei iOS-PWA Cold Start)
- [ ] Flugmodus aus → sofort uncached Tour anklicken → Toast „Verbindung instabil", User bleibt auf community-home
- [ ] Wenige Sekunden warten, nochmal klicken → lädt jetzt korrekt, kein App-Restart nötig
- [ ] Map-Tab offen, Flugmodus an → dark area beim Pan → Flugmodus aus → Tiles erscheinen ohne Pan/Zoom
- [ ] Tour wirklich (Admin) löschen + andere Browser-Session → Tour anklicken → State aktualisiert (PGRST116 propagiert weiter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)