### PR TITLE
Hard-reload on online comeback; multi-stage cold-start tile redraw

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -528,21 +528,49 @@ function startForegroundRefresh() {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') refreshCurrentView({ force: true });
   });
-  window.addEventListener('online', () => {
-    // Wenn der User vorher offline war, hat Leaflet TileLayer die fehlgeschlagenen
-    // (oder leeren-PNG-) Tiles als "loaded" markiert und fragt sie nicht neu an.
-    // Beim Wiederkehren der Verbindung explizit redrawen, sonst bleibt die Karte
-    // dunkel bis der User pannt/zoomt.
-    _redrawAllMapTiles();
-    // Ebenso ggf. fehlende GPX-Geometrie laden, falls der User noch im Map-Tab
-    // ist und sie offline nicht gecached war.
-    if (state.view === 'tour' && state.currentTab === 'map' && typeof ensureCurrentTourRouteLoaded === 'function') {
-      ensureCurrentTourRouteLoaded().catch(() => {});
-    }
-    refreshCurrentView({ force: true });
-  });
+  window.addEventListener('online', _scheduleOnlineReload);
   window.addEventListener('focus', () => refreshCurrentView({ force: true }));
 }
+
+/**
+ * Beim Online-Wiederkehr macht die App einen vollen Page-Reload anstatt
+ * Tiles/State manuell zu reparieren. Grund: iOS Safari behält nach Flugmodus
+ * gerne kaputte Network-Sockets — `navigator.onLine` sagt true, aber Fetches
+ * scheitern weiter, bis der Tab neu geladen wird. Ein Reload löst das
+ * zuverlässig.
+ *
+ * Guards:
+ *  - Nicht reloaden wenn User gerade tippt (Input/Textarea aktiv)
+ *  - Nicht reloaden wenn ein Modal offen ist (würde Form-State verlieren)
+ *  - Nur einmal pro Session pro online-Übergang
+ *  - Nicht reloaden wenn wir uns gar nicht erinnern offline gewesen zu sein
+ *    (mancher Browser feuert online auch direkt nach App-Start)
+ */
+let _wasOffline = !navigator.onLine;
+let _onlineReloadScheduled = false;
+function _scheduleOnlineReload() {
+  if (!_wasOffline) return; // war nie offline → nichts zu tun
+  if (_onlineReloadScheduled) return;
+  _onlineReloadScheduled = true;
+
+  const tryReload = () => {
+    // Guards: User nicht beim Tippen / mit offenem Modal stören
+    if (_isInteractiveElementActive() || _hasVisibleBlockingUi()) {
+      // 5s später erneut versuchen
+      setTimeout(tryReload, 5000);
+      return;
+    }
+    if (typeof toast === 'function') toast('Verbindung wiederhergestellt — lade neu…');
+    setTimeout(() => location.reload(), 600);
+  };
+
+  // Kurzer Delay damit iOS-Socket sich beruhigt + Toast-Zeit
+  setTimeout(tryReload, 800);
+}
+window.addEventListener('offline', () => {
+  _wasOffline = true;
+  _onlineReloadScheduled = false;
+});
 
 /**
  * Forciere TileLayer-Redraw auf allen aktiven Leaflet-Maps. Wird beim Online-

--- a/js/map.js
+++ b/js/map.js
@@ -391,16 +391,26 @@ function initMap(tour) {
   // Worker noch nicht die Kontrolle übernommen hat, gehen die ersten Tile-
   // Requests am SW vorbei direkt ans Netzwerk — das schlägt offline fehl
   // und die Tiles bleiben als "loaded" markiert (broken/empty), die Karte
-  // bleibt dunkel. Sobald der SW ready ist, alle Tiles neu zeichnen.
-  if ('serviceWorker' in navigator && navigator.serviceWorker.ready) {
-    navigator.serviceWorker.ready
-      .then(() => {
-        if (mapInstance && tileLayer && typeof tileLayer.redraw === 'function') {
-          tileLayer.redraw();
-        }
-      })
-      .catch(() => {});
+  // bleibt dunkel. Mehrere Versuche zum Tile-Redraw verteilt, damit der SW
+  // garantiert die Kontrolle hat:
+  //  • sofort wenn SW.ready resolvet
+  //  • bei controllerchange (falls SW erst nach dem Mount aktiv wird)
+  //  • zusätzlich nach 1s und 3s als Brute-Force gegen iOS-Eigenheiten
+  const redraw = () => {
+    if (!mapInstance || !tileLayer || typeof tileLayer.redraw !== 'function') return;
+    console.log('[map] redrawing tiles, SW controller:', !!navigator.serviceWorker?.controller);
+    tileLayer.redraw();
+  };
+  if ('serviceWorker' in navigator) {
+    if (navigator.serviceWorker.ready) {
+      navigator.serviceWorker.ready.then(redraw).catch(() => {});
+    }
+    if (!navigator.serviceWorker.controller) {
+      navigator.serviceWorker.addEventListener('controllerchange', redraw, { once: true });
+    }
   }
+  setTimeout(redraw, 1000);
+  setTimeout(redraw, 3000);
 
   if (data) drawGPX(data);
 }


### PR DESCRIPTION
## Symptome (nach PR #118)

1. **Karte bleibt dunkel beim Offline-Cold-Start** — Tile-Redraws auf SW.ready haben es nicht behoben.
2. **Online-Wiederkehr-Recovery greift nicht** — die App zeigt jetzt brav den „Verbindung instabil"-Toast, aber selbst nach mehrfachem Retry kommt nichts. Erst App-Neustart hilft.

## Pragmatischer Fix: Hard-Reload beim Online-Comeback

Statt gegen iOS-Eigenheiten anzukämpfen: wenn die App eine echte offline→online-Transition beobachtet, machen wir einen vollen `location.reload()`. Das ist exakt das, was ein App-Neustart macht — Network-Sockets werden frisch initialisiert, alle iOS-Eigenheiten verschwinden.

**Guards** in `_scheduleOnlineReload` (`js/app.js`):
- Nur reloaden wenn wir tatsächlich offline waren (`_wasOffline === true`)
- Einmal pro Online-Übergang
- Nicht reloaden wenn User gerade tippt (Input/Textarea fokussiert) — wartet 5s und versucht erneut
- Nicht reloaden wenn ein Modal offen ist — wartet 5s und versucht erneut
- Toast „Verbindung wiederhergestellt — lade neu…" mit 600ms Delay vor dem Reload, damit der User den Hinweis sieht

## Cold-Start Dark Map: Brute-Force Multi-Stage-Redraw

Theorie: Beim PWA-Cold-Start hat der Service Worker auf iOS manchmal noch nicht die Page-Kontrolle übernommen, wenn die ersten Tile-Requests fliegen. Ein einzelner Redraw auf `SW.ready` kann zu früh kommen.

Fix in `initMap` (`js/map.js`): Tiles werden auf 4 Wegen neu gezeichnet:
1. Sobald `navigator.serviceWorker.ready` resolvet
2. Bei `controllerchange`-Event (SW übernimmt erst nachträglich Kontrolle)
3. Brute-Force nach 1 Sekunde
4. Brute-Force nach 3 Sekunden

Plus `console.log` mit dem Controller-Status für Diagnose, falls es weiter dunkel bleibt.

## Test plan

- [ ] Online: Tour-Map laden, App schließen, Flugmodus, App öffnen → Tour öffnen → Karten-Tab → Tiles erscheinen (eine der Redraw-Stages greift)
- [ ] Falls weiter dunkel: Console öffnen → Logs `[map] redrawing tiles, SW controller: true/false` melden
- [ ] Flugmodus aus → Toast „Verbindung wiederhergestellt — lade neu…" → Auto-Reload
- [ ] Flugmodus aus während im Chat tippen → kein Reload solange Tastatur offen → 5s nach Verlassen vom Input → Reload
- [ ] Flugmodus aus mit offenem Modal → kein Reload solange Modal offen

🤖 Generated with [Claude Code](https://claude.com/claude-code)