### PR TITLE
Update check-in tour selection

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -162,20 +162,18 @@ async function _loadViewData(view) {
 
     if (view === 'community-home') {
       await loadHomeData();
-      // Determine next upcoming tour (needed for checkins + plan dates)
-      const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
-      const nextTour = (state.tours || [])
-        .filter(t => new Date((t.end_date || t.date) + 'T23:59:59') >= todayMidnight)
-        .sort((a,b) => new Date(a.date) - new Date(b.date))[0];
+      // Determine check-in tour (current tour wins until it is over, unless
+      // another tour starts during it and is one day away).
+      const checkinTour = getCheckinTourInfo(state.tours || [])?.tour || null;
       // Run all remaining fetches in parallel — none depend on each other
       await Promise.all([
         computePlanningBadges(),
         computeMediaBadges(),
-        nextTour
-          ? loadTourCheckins(nextTour.id).then(r => { state.tourCheckins[nextTour.id] = r; })
+        checkinTour
+          ? loadTourCheckins(checkinTour.id).then(r => { state.tourCheckins[checkinTour.id] = r; })
           : Promise.resolve(),
-        nextTour
-          ? loadNextTourPlanDates(nextTour.id)
+        checkinTour
+          ? loadNextTourPlanDates(checkinTour.id)
           : Promise.resolve(),
       ]);
     }

--- a/js/events.js
+++ b/js/events.js
@@ -605,12 +605,7 @@ function attachEvents() {
 
   /* --- Check-in weather forecast (async, community-home view) --- */
   if (state.view === 'community-home') {
-    const nextTour = (state.tours || [])
-      .filter(t => {
-        const end = t.end_date && t.end_date !== t.date ? t.end_date : t.date;
-        return new Date(end + 'T23:59:59') >= new Date();
-      })
-      .sort((a, b) => new Date(a.date) - new Date(b.date))[0];
+    const nextTour = getCheckinTourInfo(state.tours || [])?.tour || null;
     const treffpunktLink = nextTour
       ? (state.tourPlanDates || []).find(pd => pd.type === 'treffpunkt' && pd.maps_link)?.maps_link
       : null;

--- a/js/render.js
+++ b/js/render.js
@@ -2366,8 +2366,10 @@ function renderCommunityHome() {
       ? `<div class="tour-grid">${tourCards(filteredTours)}</div>`
       : `<div style="text-align:center;padding:40px 20px;color:var(--muted);font-size:14px">Keine Touren in dieser Kategorie.</div>`;
 
-  // Check-in box — next upcoming tour: participant grid + weather forecast
-  const nextTour = upcoming[0] || null;
+  // Check-in box — current tour wins until it is over; overlapping next tour
+  // takes over one day before its start.
+  const checkinInfo = getCheckinTourInfo(tours);
+  const nextTour = checkinInfo?.tour || null;
   const checkInBox = nextTour ? (() => {
     const tStart = new Date(nextTour.date + 'T12:00:00');
     const tEnd   = nextTour.end_date && nextTour.end_date !== nextTour.date ? new Date(nextTour.end_date + 'T12:00:00') : null;
@@ -2383,7 +2385,14 @@ function renderCommunityHome() {
     const todayMidnightCI = new Date(); todayMidnightCI.setHours(0, 0, 0, 0);
     const tourMidnight    = new Date(nextTour.date + 'T00:00:00');
     const diffDays = Math.round((tourMidnight - todayMidnightCI) / 86400000);
-    const countdown = diffDays <= 0 ? 'HEUTE' : diffDays === 1 ? 'IN 1 TAG' : `IN ${diffDays} TAGEN`;
+    const endMidnight = new Date((nextTour.end_date && nextTour.end_date !== nextTour.date ? nextTour.end_date : nextTour.date) + 'T00:00:00');
+    const remainingDays = Math.max(0, Math.round((endMidnight - todayMidnightCI) / 86400000));
+    const isCurrentCheckinTour = checkinInfo?.status === 'current';
+    const countdown = isCurrentCheckinTour
+      ? (remainingDays <= 0 ? 'NOCH HEUTE' : remainingDays === 1 ? 'NOCH 1 TAG' : `NOCH ${remainingDays} TAGE`)
+      : (diffDays <= 0 ? 'HEUTE' : diffDays === 1 ? 'IN 1 TAG' : `IN ${diffDays} TAGEN`);
+    const checkinLabel = isCurrentCheckinTour ? 'AKTUELLE TOUR' : 'NÄCHSTE TOUR';
+    const pulseLabel = isCurrentCheckinTour ? remainingDays <= 10 : diffDays <= 10;
 
     const memberIds = (state.tourMemberIds?.[nextTour.id] || []);
     const adminId   = nextTour.admin_id;
@@ -2438,7 +2447,7 @@ function renderCommunityHome() {
     <div class="checkin-box" data-checkin-tour="${tourId}">
       <div class="checkin-header">
         <div class="checkin-header-nav checkin-header-info" data-open-tour="${tourId}" title="Tour öffnen">
-          <div class="checkin-label${diffDays <= 10 ? ' checkin-label--pulse' : ''}">● ${countdown} · NÄCHSTE TOUR</div>
+          <div class="checkin-label${pulseLabel ? ' checkin-label--pulse' : ''}">● ${countdown} · ${checkinLabel}</div>
           <div class="checkin-title">${esc(nextTour.name)}</div>
           <div class="checkin-meta">${dateStr}${nextTour.destination ? ' · ' + esc(nextTour.destination) : ''}</div>
         </div>

--- a/js/utils.js
+++ b/js/utils.js
@@ -509,6 +509,54 @@ function getISOWeek(d) {
   return Math.ceil(((date - yearStart) / 86400000 + 1) / 7);
 }
 
+function _tourDay(dateStr) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr + 'T00:00:00');
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+function _addDays(date, days) {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function getCheckinTourInfo(tours, now = new Date()) {
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+
+  const items = (tours || [])
+    .map(t => {
+      const start = _tourDay(t.date);
+      const end = _tourDay(t.end_date && t.end_date !== t.date ? t.end_date : t.date);
+      if (!start || !end) return null;
+      return { tour: t, start, end };
+    })
+    .filter(Boolean)
+    .filter(item => item.end >= today)
+    .sort((a, b) => a.start - b.start);
+
+  const current = items.find(item => item.start <= today && item.end >= today);
+  if (current) {
+    const overlappingNext = items.find(item =>
+      item.tour.id !== current.tour.id
+      && item.start > current.start
+      && item.start <= current.end
+      && today >= _addDays(item.start, -1)
+    );
+    const selected = overlappingNext || current;
+    return {
+      tour: selected.tour,
+      status: selected.start <= today ? 'current' : 'upcoming',
+      start: selected.start,
+      end: selected.end,
+    };
+  }
+
+  const next = items[0];
+  return next ? { tour: next.tour, status: 'upcoming', start: next.start, end: next.end } : null;
+}
+
 /* ----------------------------------------------------------
    Emoji Picker
    ---------------------------------------------------------- */


### PR DESCRIPTION
## Änderungen
- Check-in-Karte nutzt jetzt eine gemeinsame Tour-Auswahlregel für Datenload, Rendering und Wetter.
- Eine laufende Tour bleibt bis zu ihrem Ende die Check-in-Tour.
- Wenn eine nächste Tour während der laufenden Tour startet, übernimmt sie ab einem Tag vor Start.
- Während einer laufenden Tour zeigt die Karte `NOCH x TAGE · AKTUELLE TOUR` statt `IN x TAGEN · NÄCHSTE TOUR`.

## Warum
Die Check-in-Karte sollte während einer laufenden Tour nicht schon auf die nächste normale Tour springen. Die Ausnahme deckt überlappende Touren ab, damit die nachfolgende Tour rechtzeitig sichtbar wird.

## Checks
- `node --check js/utils.js`
- `node --check js/app.js`
- `node --check js/render.js`
- `node --check js/events.js`
- Manuelle Datums-Szenarien per Node geprüft
