### PR TITLE
Add waypoint planning shortcut

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -958,6 +958,7 @@ async function addPlanDate(date, label, type = 'sonstiger', mapsLink = '', meeti
       details:        display,
     }).catch(e => console.warn('[notify treffpunkt]', e));
   }
+  return data;
 }
 
 async function loadNextTourPlanDates(tourId) {

--- a/js/events.js
+++ b/js/events.js
@@ -154,6 +154,12 @@ function attachEvents() {
     if (e.target.id === 'community-settings-modal') closeCommunitySettingsModal();
   });
 
+  /* --- Tour settings modal close --- */
+  document.getElementById('tour-settings-modal-close')?.addEventListener('click', closeTourSettingsModal);
+  document.getElementById('tour-settings-modal')?.addEventListener('click', (e) => {
+    if (e.target.id === 'tour-settings-modal') closeTourSettingsModal();
+  });
+
   /* --- Generic "back" buttons --- */
   document.querySelectorAll('#back-home').forEach(el => {
     el.addEventListener('click', () => {
@@ -607,7 +613,7 @@ function attachEvents() {
   if (state.view === 'community-home') {
     const nextTour = getCheckinTourInfo(state.tours || [])?.tour || null;
     const treffpunktLink = nextTour
-      ? (state.tourPlanDates || []).find(pd => pd.type === 'treffpunkt' && pd.maps_link)?.maps_link
+      ? getCheckinTreffpunkte(state.tourPlanDates || []).find(pd => pd.maps_link)?.maps_link
       : null;
     if (nextTour) {
       _loadCheckinWeather(nextTour.id, nextTour.destination, nextTour.date, nextTour.end_date || nextTour.date, treffpunktLink, nextTour);
@@ -1142,6 +1148,32 @@ function attachMapEvents() {
     }
   }, { once: false });
 
+  mapContainer?.addEventListener('click', e => {
+    const btn = e.target.closest('[data-wp-plan]');
+    if (!btn) return;
+    e.preventDefault();
+    state.pendingPlanDate = {
+      tourId: state.currentTourId,
+      type: 'treffpunkt',
+      label: btn.dataset.wpName || 'Wegpunkt',
+      mapsLink: btn.dataset.wpMaps || googleMapsLinkForLatLon(btn.dataset.wpLat, btn.dataset.wpLon),
+      fromWaypoint: true,
+    };
+    mapInstance?.closePopup?.();
+    const container = document.getElementById('map-container');
+    if (container?.classList.contains('map-fullscreen-active')) _cssFullscreen(container, false);
+    state.currentTab = 'info';
+    markTabSeen(state.currentTourId, 'info');
+    computeTabBadges(state.currentTourId);
+    _refreshTabBar();
+    const tc = document.getElementById('tab-content');
+    if (tc && state.currentTour) {
+      tc.innerHTML = renderTab(state.currentTour);
+      afterTabRender();
+      setTimeout(() => document.getElementById('add-date')?.focus(), 50);
+    }
+  });
+
   /* GPX upload (admin only) */
   document.getElementById('gpx-up')?.addEventListener('change', async e => {
     if (e.target.dataset.busy === '1') return;
@@ -1391,62 +1423,8 @@ function _appendChatMessage(msg) {
    ---------------------------------------------------------- */
 
 function attachInfoEvents() {
-  /* Distance dropdown: show/hide manual input */
-  document.getElementById('dist-source')?.addEventListener('change', e => {
-    const wrap = document.getElementById('dist-manual-wrap');
-    if (wrap) wrap.style.display = e.target.value === 'manual' ? 'block' : 'none';
-  });
-
-  /* Save edits (name + dates + destination + description + optional distance) */
-  document.getElementById('edit-save')?.addEventListener('click', async () => {
-    const name  = (document.getElementById('edit-name')?.value  || '').trim();
-    const date  =  document.getElementById('edit-date')?.value  || '';
-    const edate =  document.getElementById('edit-edate')?.value || '';
-    if (!name) { toast('Tour-Name darf nicht leer sein.', 'error'); return; }
-    if (!date) { toast('Startdatum darf nicht leer sein.', 'error'); return; }
-
-    // Distance from dropdown (if present)
-    const distSource = document.getElementById('dist-source')?.value;
-    let dist = '';
-    let surfaceDisplay = null;
-    if (distSource) {
-      const gpxData = normalizeGPXRoute(state.currentTour?.gpx_route);
-      if (distSource === 'total' && gpxData)       dist = calculateTotalDistance(gpxData);
-      else if (distSource.startsWith('track:') && gpxData) dist = calculateTrackDistance(gpxData, parseInt(distSource.split(':')[1]));
-      else if (distSource === 'manual') dist = (document.getElementById('dist-manual')?.value || '').trim();
-      surfaceDisplay = buildSurfaceDisplay(state.currentTour, distSource);
-    }
-
-    const updates = {
-      name,
-      date,
-      end_date:    edate || null,
-      destination: (document.getElementById('edit-dest')?.value || '').trim(),
-      description: (document.getElementById('edit-desc')?.value || '').trim(),
-      ...(dist ? { distance: dist } : {}),
-      ...(surfaceDisplay ? { surface_display: surfaceDisplay } : {}),
-    };
-    try {
-      await updateTourInfo(updates);
-      toast('✓ Gespeichert');
-      const hn = document.querySelector('.tour-detail-title'); if (hn) hn.textContent = name;
-      const hd = document.getElementById('hdr-dest'); if (hd) hd.textContent = updates.destination || 'Kein Ziel';
-      const id = document.getElementById('info-dest'); if (id) id.textContent = updates.destination || '—';
-      if (dist) { const hdi = document.getElementById('hdr-dist'); if (hdi) hdi.textContent = dist; }
-      _refreshInfoTab();
-    } catch (e) { toast(e.message, 'error'); }
-  });
-
-  /* Delete tour (admin only) */
-  document.getElementById('delete-tour-btn')?.addEventListener('click', async () => {
-    const name = state.currentTour?.name || 'diese Tour';
-    if (!confirm(`„${name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.`)) return;
-    setBtn('delete-tour-btn', true, '');
-    try {
-      await deleteTour();
-      toast('Tour gelöscht');
-      await navigateTo('community-home');
-    } catch (e) { toast(e.message, 'error'); setBtn('delete-tour-btn', false, '🗑️ Tour endgültig löschen'); }
+  document.getElementById('tour-settings-toggle')?.addEventListener('click', () => {
+    openTourSettingsModal();
   });
 
   /* Tour calendar navigation */
@@ -1468,7 +1446,19 @@ function attachInfoEvents() {
     const ti = t === 'treffpunkt' ? (document.getElementById('add-time')?.value || '') : '';
     if (!d) { toast('Bitte Datum wählen.', 'error'); return; }
     try {
-      await addPlanDate(d, l, t, m, ti);
+      const pendingFromWaypoint = state.pendingPlanDate?.tourId === state.currentTourId && state.pendingPlanDate?.fromWaypoint;
+      const existingTreffpunkte = t === 'treffpunkt' && pendingFromWaypoint
+        ? (state.tourPlanDates || []).filter(pd => pd.type === 'treffpunkt')
+        : [];
+      const replaceTreffpunkt = existingTreffpunkte.length ? await confirmTreffpunktReplace() : false;
+      const oldTreffpunkte = replaceTreffpunkt ? existingTreffpunkte : [];
+      const created = await addPlanDate(d, l, t, m, ti);
+      for (const pd of oldTreffpunkte) {
+        if (pd.id !== created?.id) await deletePlanDate(pd.id);
+      }
+      state.pendingPlanDate = null;
+      await loadNextTourPlanDates(state.currentTourId);
+      state.currentTab = 'info';
       _refreshInfoTab();
     } catch (e) { toast(e.message, 'error'); }
   });
@@ -1481,6 +1471,43 @@ function attachInfoEvents() {
         _refreshInfoTab();
       } catch (e) { toast(e.message, 'error'); }
     });
+  });
+}
+
+function confirmTreffpunktReplace() {
+  return new Promise(resolve => {
+    document.getElementById('treffpunkt-replace-confirm')?.remove();
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay settings-modal-overlay';
+    overlay.id = 'treffpunkt-replace-confirm';
+    overlay.style.display = 'flex';
+    overlay.innerHTML = `
+      <div class="settings-modal-content" style="max-width:420px">
+        <div class="settings-modal-header">
+          <div class="settings-modal-title">Aktuellen Treffpunkt ersetzen?</div>
+        </div>
+        <div class="settings-modal-body">
+          <div style="color:var(--muted);font-size:14px;margin-bottom:18px">
+            Es gibt bereits einen Treffpunkt. Soll der neue Planungstermin den aktuellen Treffpunkt ersetzen?
+          </div>
+          <div style="display:flex;gap:10px;justify-content:flex-end">
+            <button class="btn btn-ghost btn-sm" id="treffpunkt-replace-no">Nein</button>
+            <button class="btn btn-primary btn-sm" id="treffpunkt-replace-yes">Ja</button>
+          </div>
+        </div>
+      </div>`;
+    const close = value => {
+      overlay.remove();
+      document.body.style.overflow = '';
+      resolve(value);
+    };
+    document.body.appendChild(overlay);
+    document.body.style.overflow = 'hidden';
+    overlay.addEventListener('click', e => {
+      if (e.target === overlay) close(false);
+    });
+    overlay.querySelector('#treffpunkt-replace-no')?.addEventListener('click', () => close(false));
+    overlay.querySelector('#treffpunkt-replace-yes')?.addEventListener('click', () => close(true));
   });
 }
 
@@ -2814,6 +2841,23 @@ async function reloadCommunitySettingsModal() {
   }
 }
 
+function openTourSettingsModal() {
+  const overlay = document.getElementById('tour-settings-modal');
+  const body    = document.getElementById('tour-settings-modal-body');
+  if (!overlay || !body) return;
+  if (!state.currentTour) { toast('Keine Tour geladen', 'error'); return; }
+  overlay.style.display = 'flex';
+  document.body.style.overflow = 'hidden';
+  body.innerHTML = renderTourSettingsBody(state.currentTour);
+  attachTourSettingsModalEvents();
+}
+
+function closeTourSettingsModal() {
+  const overlay = document.getElementById('tour-settings-modal');
+  if (overlay) overlay.style.display = 'none';
+  document.body.style.overflow = '';
+}
+
 /* ----------------------------------------------------------
    Scoped event binders — called only when the modal body is
    (re-)rendered, so no stacking on the global attachEvents().
@@ -2935,6 +2979,71 @@ function attachProfileModalEvents() {
       toast('Fehler: ' + (err.message || 'unbekannt'), 'error');
     }
     await refreshPushButtonState();
+  });
+}
+
+function attachTourSettingsModalEvents() {
+  document.getElementById('dist-source')?.addEventListener('change', e => {
+    const wrap = document.getElementById('dist-manual-wrap');
+    if (wrap) wrap.style.display = e.target.value === 'manual' ? 'block' : 'none';
+  });
+
+  document.getElementById('edit-save')?.addEventListener('click', async () => {
+    const name  = (document.getElementById('edit-name')?.value  || '').trim();
+    const date  =  document.getElementById('edit-date')?.value  || '';
+    const edate =  document.getElementById('edit-edate')?.value || '';
+    if (!name) { toast('Tour-Name darf nicht leer sein.', 'error'); return; }
+    if (!date) { toast('Startdatum darf nicht leer sein.', 'error'); return; }
+
+    const distSource = document.getElementById('dist-source')?.value;
+    let dist = '';
+    let surfaceDisplay = null;
+    if (distSource) {
+      const gpxData = normalizeGPXRoute(state.currentTour?.gpx_route);
+      if (distSource === 'total' && gpxData)       dist = calculateTotalDistance(gpxData);
+      else if (distSource.startsWith('track:') && gpxData) dist = calculateTrackDistance(gpxData, parseInt(distSource.split(':')[1]));
+      else if (distSource === 'manual') dist = (document.getElementById('dist-manual')?.value || '').trim();
+      surfaceDisplay = buildSurfaceDisplay(state.currentTour, distSource);
+    }
+
+    const updates = {
+      name,
+      date,
+      end_date:    edate || null,
+      destination: (document.getElementById('edit-dest')?.value || '').trim(),
+      description: (document.getElementById('edit-desc')?.value || '').trim(),
+      ...(dist ? { distance: dist } : {}),
+      ...(surfaceDisplay ? { surface_display: surfaceDisplay } : {}),
+    };
+    setBtn('edit-save', true, '');
+    try {
+      await updateTourInfo(updates);
+      toast('✓ Gespeichert');
+      const hn = document.querySelector('.tour-detail-title'); if (hn) hn.textContent = name;
+      const hd = document.getElementById('hdr-dest'); if (hd) hd.textContent = updates.destination || 'Kein Ziel';
+      const id = document.getElementById('info-dest'); if (id) id.textContent = updates.destination || '—';
+      if (dist) { const hdi = document.getElementById('hdr-dist'); if (hdi) hdi.textContent = dist; }
+      closeTourSettingsModal();
+      _refreshInfoTab();
+    } catch (e) {
+      toast(e.message, 'error');
+      setBtn('edit-save', false, 'Änderungen speichern');
+    }
+  });
+
+  document.getElementById('delete-tour-btn')?.addEventListener('click', async () => {
+    const name = state.currentTour?.name || 'diese Tour';
+    if (!confirm(`„${name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.`)) return;
+    setBtn('delete-tour-btn', true, '');
+    try {
+      await deleteTour();
+      toast('Tour gelöscht');
+      closeTourSettingsModal();
+      await navigateTo('community-home');
+    } catch (e) {
+      toast(e.message, 'error');
+      setBtn('delete-tour-btn', false, '🗑️ Tour endgültig löschen');
+    }
   });
 }
 

--- a/js/map.js
+++ b/js/map.js
@@ -473,7 +473,17 @@ function drawGPX(data) {
     });
 
     const symLabel = w.sym ? `<br><span style="font-size:11px;color:#aaa">${esc(w.sym)}</span>` : '';
-    const popup = `<strong>${esc(w.name)}</strong>${symLabel}${w.desc ? `<br><span style="font-size:12px;color:#888">${esc(w.desc)}</span>` : ''}`;
+    const mapsLink = typeof googleMapsLinkForLatLon === 'function' ? googleMapsLinkForLatLon(w.lat, w.lon) : '';
+    const canCreatePlanDate = typeof isCurrentUserAdmin === 'function' && isCurrentUserAdmin();
+    const popup = `<strong>${esc(w.name)}</strong>${symLabel}${w.desc ? `<br><span style="font-size:12px;color:#888">${esc(w.desc)}</span>` : ''}${canCreatePlanDate ? `
+      <div style="margin-top:10px">
+        <button class="btn btn-ghost btn-sm map-waypoint-plan-btn"
+          data-wp-plan="1"
+          data-wp-name="${esc(w.name)}"
+          data-wp-lat="${esc(String(w.lat))}"
+          data-wp-lon="${esc(String(w.lon))}"
+          data-wp-maps="${esc(mapsLink)}">+ Planungstermin</button>
+      </div>` : ''}`;
     const marker = L.marker([w.lat, w.lon], { icon })
       .addTo(mapInstance)
       .bindPopup(popup)

--- a/js/render.js
+++ b/js/render.js
@@ -1155,6 +1155,57 @@ function renderTour() {
   <div class="tab-content" id="tab-content">
     ${renderTab(tour)}
   </div>
+</div>
+${renderTourSettingsModal()}`;
+}
+
+function renderTourSettingsBody(tour) {
+  return `
+  <div class="form-group">
+    <label>Tour-Name</label>
+    <input type="text" id="edit-name" value="${esc(tour.name)}" maxlength="60" />
+  </div>
+  <div class="form-row">
+    <div class="form-group">
+      <label>Startdatum</label>
+      <input type="date" id="edit-date" value="${esc(tour.date || '')}" />
+    </div>
+    <div class="form-group">
+      <label>Enddatum</label>
+      <input type="date" id="edit-edate" value="${esc(tour.end_date || '')}" />
+    </div>
+  </div>
+  <div class="form-group">
+    <label>Ziel / Region</label>
+    <input type="text" id="edit-dest" value="${esc(tour.destination || '')}" />
+  </div>
+  <div class="form-group">
+    <label>Beschreibung</label>
+    <textarea id="edit-desc">${esc(tour.description || '')}</textarea>
+  </div>
+  <div class="divider" style="margin:14px 0 12px"></div>
+  <h4 style="font-size:12px;font-weight:600;margin-bottom:8px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">
+    📏 Distanz berechnen
+  </h4>
+  ${renderDistanceSelector(tour)}
+  <button class="btn btn-primary btn-sm" id="edit-save">Änderungen speichern</button>
+  <div class="divider"></div>
+  <h3 style="font-size:14px;font-weight:600;margin-bottom:10px;color:var(--danger)">⚠️ Gefahrenzone</h3>
+  <button class="btn btn-danger btn-sm" id="delete-tour-btn" style="width:100%;justify-content:center">🗑️ Tour endgültig löschen</button>`;
+}
+
+function renderTourSettingsModal() {
+  return `
+<div class="modal-overlay settings-modal-overlay" id="tour-settings-modal" style="display:none">
+  <div class="settings-modal-content">
+    <div class="settings-modal-header">
+      <div class="settings-modal-title">⚙️ Tour Einstellungen</div>
+      <button class="btn btn-ghost btn-sm" id="tour-settings-modal-close" title="Schliessen" style="font-size:18px;padding:6px 14px">✕</button>
+    </div>
+    <div class="settings-modal-body" id="tour-settings-modal-body">
+      <div style="color:var(--muted);padding:20px">Lädt…</div>
+    </div>
+  </div>
 </div>`;
 }
 
@@ -1724,6 +1775,10 @@ window._dismissInfoBanner = function() {
 
 function renderInfoTab(tour) {
   const isAdmin = isCurrentUserAdmin();
+  const pendingPlanDate = state.pendingPlanDate?.tourId === tour.id ? state.pendingPlanDate : null;
+  const pendingType = pendingPlanDate?.type || 'treffpunkt';
+  const pendingLabel = pendingPlanDate?.label || '';
+  const pendingMapsLink = pendingPlanDate?.mapsLink || '';
 
   const bannerItems = state.infoBannerItems || [];
   const infoBanner = bannerItems.length ? `
@@ -1748,7 +1803,10 @@ function renderInfoTab(tour) {
 
       <!-- Left: tour details + admin edit form -->
       <div>
-        <h2 style="font-family:var(--font-display);font-size:24px;letter-spacing:0.5px;margin-bottom:14px">Tour-Details</h2>
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:14px">
+          <h2 style="font-family:var(--font-display);font-size:24px;letter-spacing:0.5px;margin:0">Tour-Details</h2>
+          ${isAdmin ? `<button class="btn btn-ghost btn-sm" id="tour-settings-toggle">⚙️ Einstellungen</button>` : ''}
+        </div>
         <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:18px">
           <div class="info-block">
             <div class="info-label">Beschreibung</div>
@@ -1786,41 +1844,6 @@ function renderInfoTab(tour) {
           </div>
         </div>
 
-        ${isAdmin ? `
-        <div class="divider"></div>
-        <h3 style="font-size:14px;font-weight:600;margin-bottom:12px">⚙️ Infos bearbeiten</h3>
-        <div class="form-group">
-          <label>Tour-Name</label>
-          <input type="text" id="edit-name" value="${esc(tour.name)}" maxlength="60" />
-        </div>
-        <div class="form-row">
-          <div class="form-group">
-            <label>Startdatum</label>
-            <input type="date" id="edit-date" value="${esc(tour.date || '')}" />
-          </div>
-          <div class="form-group">
-            <label>Enddatum</label>
-            <input type="date" id="edit-edate" value="${esc(tour.end_date || '')}" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>Ziel / Region</label>
-          <input type="text" id="edit-dest" value="${esc(tour.destination || '')}" />
-        </div>
-        <div class="form-group">
-          <label>Beschreibung</label>
-          <textarea id="edit-desc">${esc(tour.description || '')}</textarea>
-        </div>
-        <div class="divider" style="margin:14px 0 12px"></div>
-        <h4 style="font-size:12px;font-weight:600;margin-bottom:8px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">
-          📏 Distanz berechnen
-        </h4>
-        ${renderDistanceSelector(tour)}
-        <button class="btn btn-primary btn-sm" id="edit-save">Änderungen speichern</button>
-        <div class="divider"></div>
-        <h3 style="font-size:14px;font-weight:600;margin-bottom:10px;color:var(--danger)">⚠️ Gefahrenzone</h3>
-        <button class="btn btn-danger btn-sm" id="delete-tour-btn" style="width:100%;justify-content:center">🗑️ Tour endgültig löschen</button>
-        ` : ''}
       </div>
 
       <!-- Right: planning calendar -->
@@ -1855,28 +1878,29 @@ function renderInfoTab(tour) {
           <div style="font-size:11px;font-weight:600;margin-bottom:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">
             Termin hinzufügen
           </div>
+          ${pendingPlanDate ? `<div style="font-size:12px;color:var(--accent);margin-bottom:10px">Wegpunkt übernommen: ${esc(pendingLabel || 'Wegpunkt')}</div>` : ''}
           <div class="form-group" style="margin-bottom:10px">
             <label>Art</label>
             <select id="pd-type" onchange="document.getElementById('pd-time-row').style.display=this.value==='treffpunkt'?'':'none'">
-              <option value="treffpunkt">📍 Treffpunkt</option>
-              <option value="sonstiger">📅 Sonstiger Termin</option>
+              <option value="treffpunkt"${pendingType === 'treffpunkt' ? ' selected' : ''}>📍 Treffpunkt</option>
+              <option value="sonstiger"${pendingType === 'sonstiger' ? ' selected' : ''}>📅 Sonstiger Termin</option>
             </select>
           </div>
           <div class="form-group" style="margin-bottom:10px">
             <label>Datum</label>
             <input type="date" id="add-date" />
           </div>
-          <div class="form-group" id="pd-time-row" style="margin-bottom:10px">
+          <div class="form-group" id="pd-time-row" style="margin-bottom:10px;display:${pendingType === 'treffpunkt' ? '' : 'none'}">
             <label>Uhrzeit (optional)</label>
             <input type="time" id="add-time" />
           </div>
           <div class="form-group" style="margin-bottom:10px">
             <label>Beschriftung (optional)</label>
-            <input type="text" id="add-label" placeholder="z.B. Parkplatz Talstation, Abfahrt…" maxlength="80" />
+            <input type="text" id="add-label" placeholder="z.B. Parkplatz Talstation, Abfahrt…" maxlength="80" value="${esc(pendingLabel)}" />
           </div>
           <div class="form-group" style="margin-bottom:12px">
             <label>Google Maps Link (optional)</label>
-            <input type="url" id="add-maps-link" placeholder="https://maps.google.com/…" />
+            <input type="url" id="add-maps-link" placeholder="https://maps.google.com/…" value="${esc(pendingMapsLink)}" />
           </div>
           <button class="btn btn-ghost btn-sm" id="add-date-btn">+ Termin hinzufügen</button>
         </div>` : ''}
@@ -2461,7 +2485,7 @@ function renderCommunityHome() {
         <div class="checkin-grid" id="checkin-grid-${tourId}">${participantGrid}</div>
       </div>
       ${(() => {
-        const treffpunkte = (state.tourPlanDates || []).filter(pd => pd.type === 'treffpunkt');
+        const treffpunkte = getCheckinTreffpunkte(state.tourPlanDates || []);
         if (!treffpunkte.length) return '';
         const rows = treffpunkte.map(pd => {
           const _pd = new Date(pd.date + 'T12:00:00');

--- a/js/state.js
+++ b/js/state.js
@@ -62,6 +62,7 @@ const state = {
   isSiteAdminUser: false,   // tour id selected in community media view
   tabBadges:     {},
   tourCalMonth:  null,
+  pendingPlanDate: null,
 
   /* Check-ins: tourId → Set of user_ids who confirmed */
   tourCheckins:  {},

--- a/js/utils.js
+++ b/js/utils.js
@@ -557,6 +557,27 @@ function getCheckinTourInfo(tours, now = new Date()) {
   return next ? { tour: next.tour, status: 'upcoming', start: next.start, end: next.end } : null;
 }
 
+function googleMapsLinkForLatLon(lat, lon) {
+  const cleanLat = Number(lat);
+  const cleanLon = Number(lon);
+  if (!Number.isFinite(cleanLat) || !Number.isFinite(cleanLon)) return '';
+  return `https://www.google.com/maps/search/?api=1&query=${cleanLat.toFixed(6)},${cleanLon.toFixed(6)}`;
+}
+
+function getCheckinTreffpunkte(planDates) {
+  return (planDates || [])
+    .filter(pd => pd.type === 'treffpunkt')
+    .map((pd, index) => ({ pd, index }))
+    .sort((a, b) => {
+      const aCreated = new Date(a.pd.created_at || '').getTime();
+      const bCreated = new Date(b.pd.created_at || '').getTime();
+      if (Number.isFinite(aCreated) && Number.isFinite(bCreated) && aCreated !== bCreated) return bCreated - aCreated;
+      if (Number.isFinite(aCreated) !== Number.isFinite(bCreated)) return Number.isFinite(bCreated) ? 1 : -1;
+      return b.index - a.index;
+    })
+    .map(item => item.pd);
+}
+
 /* ----------------------------------------------------------
    Emoji Picker
    ---------------------------------------------------------- */


### PR DESCRIPTION
## Änderungen
- Wegpunkte auf der Tour-Karte können als Planungstermin übernommen werden.
- Der Info-Tab öffnet automatisch mit vorausgefülltem Treffpunkt-Formular inklusive Google-Maps-Link aus den Wegpunkt-Koordinaten.
- Bei bestehenden Treffpunkten fragt ein Ja/Nein-Dialog erst beim Speichern, ob der aktuelle Treffpunkt ersetzt werden soll.
- Wenn mehrere Treffpunkte bleiben, nutzt die Check-in-Karte den neuesten Treffpunkt zuerst.
- Tour-Einstellungen wurden aus dem Info-Tab in ein eigenes Modal im Stil der Community-Einstellungen verschoben.

## Warum
Treffpunkte lassen sich dadurch direkt aus der GPX-/Wegpunkt-Karte übernehmen, ohne Koordinaten oder Maps-Links manuell zu kopieren. Gleichzeitig bleibt der Info-Tab übersichtlicher.

## Checks
- `node --check js/state.js`
- `node --check js/utils.js`
- `node --check js/map.js`
- `node --check js/render.js`
- `node --check js/events.js`
- `node --check js/api.js`
