### PR TITLE
Allow editing planning dates

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -961,6 +961,30 @@ async function addPlanDate(date, label, type = 'sonstiger', mapsLink = '', meeti
   return data;
 }
 
+async function updatePlanDate(id, date, label, type = 'sonstiger', mapsLink = '', meetingTime = '') {
+  const previous = state.tourPlanDates.find(d => d.id === id);
+  const updates = {
+    date,
+    label,
+    type,
+    maps_link:    mapsLink    || null,
+    meeting_time: type === 'treffpunkt' ? (meetingTime || null) : null,
+  };
+  const { data, error } = await sb
+    .from('plan_dates')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) throw new Error(error.message);
+
+  state.tourPlanDates = state.tourPlanDates.map(pd => pd.id === id ? data : pd);
+  const oldDisplay = previous ? (previous.label ? `${previous.date} (${previous.label})` : previous.date) : id;
+  const newDisplay = label ? `${date} (${label})` : date;
+  await logChange('Planungstermin geändert', oldDisplay, newDisplay);
+  return data;
+}
+
 async function loadNextTourPlanDates(tourId) {
   // Offline + bereits für diese Tour geladen → State behalten
   if (!navigator.onLine && state._loadedPlanDatesTourId === tourId && state.tourPlanDates) {

--- a/js/events.js
+++ b/js/events.js
@@ -1159,6 +1159,7 @@ function attachMapEvents() {
       mapsLink: btn.dataset.wpMaps || googleMapsLinkForLatLon(btn.dataset.wpLat, btn.dataset.wpLon),
       fromWaypoint: true,
     };
+    state.editingPlanDateId = null;
     mapInstance?.closePopup?.();
     const container = document.getElementById('map-container');
     if (container?.classList.contains('map-fullscreen-active')) _cssFullscreen(container, false);
@@ -1446,21 +1447,40 @@ function attachInfoEvents() {
     const ti = t === 'treffpunkt' ? (document.getElementById('add-time')?.value || '') : '';
     if (!d) { toast('Bitte Datum wählen.', 'error'); return; }
     try {
-      const pendingFromWaypoint = state.pendingPlanDate?.tourId === state.currentTourId && state.pendingPlanDate?.fromWaypoint;
-      const existingTreffpunkte = t === 'treffpunkt' && pendingFromWaypoint
-        ? (state.tourPlanDates || []).filter(pd => pd.type === 'treffpunkt')
-        : [];
-      const replaceTreffpunkt = existingTreffpunkte.length ? await confirmTreffpunktReplace() : false;
-      const oldTreffpunkte = replaceTreffpunkt ? existingTreffpunkte : [];
-      const created = await addPlanDate(d, l, t, m, ti);
-      for (const pd of oldTreffpunkte) {
-        if (pd.id !== created?.id) await deletePlanDate(pd.id);
+      if (state.editingPlanDateId) {
+        await updatePlanDate(state.editingPlanDateId, d, l, t, m, ti);
+        state.editingPlanDateId = null;
+      } else {
+        const pendingFromWaypoint = state.pendingPlanDate?.tourId === state.currentTourId && state.pendingPlanDate?.fromWaypoint;
+        const existingTreffpunkte = t === 'treffpunkt' && pendingFromWaypoint
+          ? (state.tourPlanDates || []).filter(pd => pd.type === 'treffpunkt')
+          : [];
+        const replaceTreffpunkt = existingTreffpunkte.length ? await confirmTreffpunktReplace() : false;
+        const oldTreffpunkte = replaceTreffpunkt ? existingTreffpunkte : [];
+        const created = await addPlanDate(d, l, t, m, ti);
+        for (const pd of oldTreffpunkte) {
+          if (pd.id !== created?.id) await deletePlanDate(pd.id);
+        }
+        state.pendingPlanDate = null;
       }
-      state.pendingPlanDate = null;
       await loadNextTourPlanDates(state.currentTourId);
       state.currentTab = 'info';
       _refreshInfoTab();
     } catch (e) { toast(e.message, 'error'); }
+  });
+
+  document.getElementById('cancel-edit-date-btn')?.addEventListener('click', () => {
+    state.editingPlanDateId = null;
+    _refreshInfoTab();
+  });
+
+  document.querySelectorAll('[data-edit-date]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      state.editingPlanDateId = btn.dataset.editDate;
+      state.pendingPlanDate = null;
+      _refreshInfoTab();
+      setTimeout(() => document.getElementById('add-date')?.focus(), 50);
+    });
   });
 
   /* Delete plan dates */
@@ -1468,6 +1488,7 @@ function attachInfoEvents() {
     btn.addEventListener('click', async () => {
       try {
         await deletePlanDate(btn.dataset.delDate);
+        if (state.editingPlanDateId === btn.dataset.delDate) state.editingPlanDateId = null;
         _refreshInfoTab();
       } catch (e) { toast(e.message, 'error'); }
     });

--- a/js/render.js
+++ b/js/render.js
@@ -1776,9 +1776,14 @@ window._dismissInfoBanner = function() {
 function renderInfoTab(tour) {
   const isAdmin = isCurrentUserAdmin();
   const pendingPlanDate = state.pendingPlanDate?.tourId === tour.id ? state.pendingPlanDate : null;
-  const pendingType = pendingPlanDate?.type || 'treffpunkt';
-  const pendingLabel = pendingPlanDate?.label || '';
-  const pendingMapsLink = pendingPlanDate?.mapsLink || '';
+  const editingPlanDate = state.editingPlanDateId
+    ? (state.tourPlanDates || []).find(pd => pd.id === state.editingPlanDateId)
+    : null;
+  const formType = editingPlanDate?.type || pendingPlanDate?.type || 'treffpunkt';
+  const formLabel = editingPlanDate?.label || pendingPlanDate?.label || '';
+  const formMapsLink = editingPlanDate?.maps_link || pendingPlanDate?.mapsLink || '';
+  const formDate = editingPlanDate?.date || '';
+  const formTime = editingPlanDate?.meeting_time ? editingPlanDate.meeting_time.slice(0, 5) : '';
 
   const bannerItems = state.infoBannerItems || [];
   const infoBanner = bannerItems.length ? `
@@ -1867,8 +1872,12 @@ function renderInfoTab(tour) {
               ${pd.label ? ` <span style="color:var(--muted)">— ${esc(pd.label)}</span>` : ''}
               ${pd.maps_link ? ` <a href="${esc(pd.maps_link)}" target="_blank" rel="noopener" class="plan-date-maps-link">Maps →</a>` : ''}
             </div>
-            ${isAdmin ? `<button class="btn btn-ghost btn-sm" data-del-date="${pd.id}"
-              style="color:var(--danger);padding:3px 8px;flex-shrink:0">✕</button>` : ''}
+            ${isAdmin ? `<div style="display:flex;gap:6px;flex-shrink:0">
+              <button class="btn btn-ghost btn-sm" data-edit-date="${pd.id}"
+                style="padding:3px 8px">Bearbeiten</button>
+              <button class="btn btn-ghost btn-sm" data-del-date="${pd.id}"
+                style="color:var(--danger);padding:3px 8px">✕</button>
+            </div>` : ''}
           </div>`;
           }).join('')}
         </div>
@@ -1876,33 +1885,36 @@ function renderInfoTab(tour) {
         ${isAdmin ? `
         <div style="margin-top:14px;background:var(--surface2);border-radius:var(--radius);padding:12px">
           <div style="font-size:11px;font-weight:600;margin-bottom:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">
-            Termin hinzufügen
+            ${editingPlanDate ? 'Termin bearbeiten' : 'Termin hinzufügen'}
           </div>
-          ${pendingPlanDate ? `<div style="font-size:12px;color:var(--accent);margin-bottom:10px">Wegpunkt übernommen: ${esc(pendingLabel || 'Wegpunkt')}</div>` : ''}
+          ${pendingPlanDate && !editingPlanDate ? `<div style="font-size:12px;color:var(--accent);margin-bottom:10px">Wegpunkt übernommen: ${esc(formLabel || 'Wegpunkt')}</div>` : ''}
           <div class="form-group" style="margin-bottom:10px">
             <label>Art</label>
             <select id="pd-type" onchange="document.getElementById('pd-time-row').style.display=this.value==='treffpunkt'?'':'none'">
-              <option value="treffpunkt"${pendingType === 'treffpunkt' ? ' selected' : ''}>📍 Treffpunkt</option>
-              <option value="sonstiger"${pendingType === 'sonstiger' ? ' selected' : ''}>📅 Sonstiger Termin</option>
+              <option value="treffpunkt"${formType === 'treffpunkt' ? ' selected' : ''}>📍 Treffpunkt</option>
+              <option value="sonstiger"${formType === 'sonstiger' ? ' selected' : ''}>📅 Sonstiger Termin</option>
             </select>
           </div>
           <div class="form-group" style="margin-bottom:10px">
             <label>Datum</label>
-            <input type="date" id="add-date" />
+            <input type="date" id="add-date" value="${esc(formDate)}" />
           </div>
-          <div class="form-group" id="pd-time-row" style="margin-bottom:10px;display:${pendingType === 'treffpunkt' ? '' : 'none'}">
+          <div class="form-group" id="pd-time-row" style="margin-bottom:10px;display:${formType === 'treffpunkt' ? '' : 'none'}">
             <label>Uhrzeit (optional)</label>
-            <input type="time" id="add-time" />
+            <input type="time" id="add-time" value="${esc(formTime)}" />
           </div>
           <div class="form-group" style="margin-bottom:10px">
             <label>Beschriftung (optional)</label>
-            <input type="text" id="add-label" placeholder="z.B. Parkplatz Talstation, Abfahrt…" maxlength="80" value="${esc(pendingLabel)}" />
+            <input type="text" id="add-label" placeholder="z.B. Parkplatz Talstation, Abfahrt…" maxlength="80" value="${esc(formLabel)}" />
           </div>
           <div class="form-group" style="margin-bottom:12px">
             <label>Google Maps Link (optional)</label>
-            <input type="url" id="add-maps-link" placeholder="https://maps.google.com/…" value="${esc(pendingMapsLink)}" />
+            <input type="url" id="add-maps-link" placeholder="https://maps.google.com/…" value="${esc(formMapsLink)}" />
           </div>
-          <button class="btn btn-ghost btn-sm" id="add-date-btn">+ Termin hinzufügen</button>
+          <div style="display:flex;gap:8px;flex-wrap:wrap">
+            <button class="btn btn-ghost btn-sm" id="add-date-btn">${editingPlanDate ? 'Termin speichern' : '+ Termin hinzufügen'}</button>
+            ${editingPlanDate ? '<button class="btn btn-ghost btn-sm" id="cancel-edit-date-btn">Abbrechen</button>' : ''}
+          </div>
         </div>` : ''}
       </div>
 

--- a/js/state.js
+++ b/js/state.js
@@ -63,6 +63,7 @@ const state = {
   tabBadges:     {},
   tourCalMonth:  null,
   pendingPlanDate: null,
+  editingPlanDateId: null,
 
   /* Check-ins: tourId → Set of user_ids who confirmed */
   tourCheckins:  {},

--- a/supabase/migrations/20260511183000_plan_dates_update_policy.sql
+++ b/supabase/migrations/20260511183000_plan_dates_update_policy.sql
@@ -1,0 +1,8 @@
+DROP POLICY IF EXISTS "Admin bearbeitet Termin" ON public.plan_dates;
+CREATE POLICY "Admin bearbeitet Termin" ON public.plan_dates
+  FOR UPDATE USING (
+    EXISTS (SELECT 1 FROM tours WHERE tours.id = plan_dates.tour_id AND tours.admin_id = (select auth.uid()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM tours WHERE tours.id = plan_dates.tour_id AND tours.admin_id = (select auth.uid()))
+  );


### PR DESCRIPTION
## Änderungen
- Bestehende Planungstermine im Info-Tab können jetzt bearbeitet werden.
- Das vorhandene Terminformular wechselt beim Klick auf "Bearbeiten" in den Bearbeiten-Modus und füllt Datum, Art, Uhrzeit, Beschriftung und Google-Maps-Link vor.
- Änderungen werden im Tour-Log als "Planungstermin geändert" protokolliert.
- Neue Supabase-RLS-Policy erlaubt Tour-Admins das Aktualisieren von `plan_dates`.

## Checks
- `node --check js/state.js`
- `node --check js/api.js`
- `node --check js/events.js`
- `node --check js/render.js`
