### PR TITLE
Add media drag-and-drop upload and per-item NEU badges

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1759,6 +1759,47 @@ select option       { background: var(--surface2); }
   pointer-events: none;
 }
 
+.media-new-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: var(--accent);
+  color: #000;
+  font-weight: 800;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  border-radius: 4px;
+  padding: 2px 6px;
+  z-index: 3;
+  pointer-events: none;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.35);
+}
+
+/* Drag & Drop overlay for media upload */
+.media-drop-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(13, 13, 16, 0.82);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+.media-drop-overlay-inner {
+  border: 3px dashed var(--accent);
+  border-radius: 16px;
+  padding: 36px 56px;
+  color: var(--accent);
+  font-size: 22px;
+  font-weight: 700;
+  text-align: center;
+  background: rgba(13, 13, 16, 0.6);
+  line-height: 1.5;
+}
+
 /* Media drag & drop reorder */
 .media-card[draggable="true"] { cursor: grab; }
 .media-card[draggable="true"]:active { cursor: grabbing; }

--- a/js/api.js
+++ b/js/api.js
@@ -533,7 +533,9 @@ function computeTabBadges(tourId) {
 
   /* ── Media ── */
   const seenMedia = getLastSeen(tourId, 'media');
-  const newMedia  = state.tourMedia.filter(m => new Date(m.created_at) > seenMedia);
+  const newMedia  = state.tourMedia.filter(m =>
+    m.user_id !== state.currentUser?.id && new Date(m.created_at) > seenMedia
+  );
   if (newMedia.length) {
     state.tabBadges.media = newMedia.map(m => ({
       text: `${m.username}: ${m.media_type === 'youtube' ? 'YouTube' : m.media_type}`,
@@ -1931,10 +1933,12 @@ async function computeMediaBadges() {
     sb.from('community_media')
       .select('id', { count: 'exact', head: true })
       .eq('community_id', cid)
+      .neq('user_id', state.currentUser.id)
       .gt('created_at', seenCm.toISOString()),
     sb.from('tour_media')
       .select('id, tour_id', { count: 'exact', head: true })
       .in('tour_id', (state.tours || []).map(t => t.id))
+      .neq('user_id', state.currentUser.id)
       .gt('created_at', seenTm.toISOString()),
   ]);
 

--- a/js/app.js
+++ b/js/app.js
@@ -183,6 +183,11 @@ async function _loadViewData(view) {
       await Promise.all([loadHomeData(), loadCommunityMedia()]);
       await computeTourMediaCounts(); // needs state.tours from loadHomeData
       state.selectedTourMedia = null;
+      // Snapshot der seen-states EINFRIEREN bevor markTabSeen läuft,
+      // damit das Rendering noch weiß, welche Items "neu" sind.
+      if (!state.mediaSeenAt) state.mediaSeenAt = {};
+      state.mediaSeenAt[`cm:${state.currentCommunityId}`] = getLastSeen(state.currentCommunityId, 'community-media').getTime();
+      state.mediaSeenAt[`tm:${state.currentCommunityId}`] = getLastSeen(state.currentCommunityId, 'tour-media').getTime();
       markTabSeen(state.currentCommunityId, 'community-media');
       markTabSeen(state.currentCommunityId, 'tour-media');
       state.mediaBadges = { community: 0, tours: 0 };
@@ -201,6 +206,11 @@ async function _loadViewData(view) {
   if (view === 'tour' && state.currentTourId) {
     await loadTourData(state.currentTourId);
     await loadTourMedia();
+    // Snapshot der Media-seen-state für diese Tour einfrieren, BEVOR das
+    // Tab-Click-Handling markTabSeen('media') auslöst. So zeigt die Galerie
+    // pro Item ein "NEU"-Label für Uploads anderer User seit letztem Besuch.
+    if (!state.mediaSeenAt) state.mediaSeenAt = {};
+    state.mediaSeenAt[`tour:${state.currentTourId}`] = getLastSeen(state.currentTourId, 'media').getTime();
     subscribeToChat(state.currentTourId);
   }
 }

--- a/js/events.js
+++ b/js/events.js
@@ -2089,63 +2089,104 @@ function _bindRemoveOpts() {
    Media tab events
    ---------------------------------------------------------- */
 
-function attachMediaEvents() {
-  /* File upload */
-  document.getElementById('media-file-input')?.addEventListener('change', async e => {
-    const files = [...e.target.files];
-    if (!files.length) return;
+async function _uploadTourMediaFiles(files) {
+  if (!files || !files.length) return;
 
-    for (const file of files) {
-      // Validate type
-      if (!ALLOWED_MEDIA_TYPES.includes(file.type)) {
-        toast(`Dateityp nicht erlaubt: ${file.type}`, 'error');
-        continue;
-      }
-      // Validate size
-      if (file.size > MAX_FILE_SIZE) {
-        toast(`Datei zu groß: ${(file.size / 1024 / 1024).toFixed(1)} MB (max ${MAX_FILE_SIZE / 1024 / 1024} MB)`, 'error');
-        continue;
-      }
-
-      const prog = document.getElementById('media-upload-progress');
-      const bar  = document.getElementById('media-upload-bar');
-      const txt  = document.getElementById('media-upload-text');
-      if (prog) prog.style.display = 'block';
-
-      try {
-        const result = await uploadToCloudinary(file, pct => {
-          if (bar) bar.style.width = pct + '%';
-          if (txt) txt.textContent = `Wird hochgeladen… ${pct}%`;
-        });
-
-        const isVideo = file.type.startsWith('video');
-        await saveTourMedia({
-          tour_id:       state.currentTourId,
-          user_id:       state.currentUser.id,
-          username:      state.currentUser.username,
-          media_type:    isVideo ? 'video' : 'image',
-          url:           result.secure_url,
-          thumbnail_url: result.eager?.[0]?.secure_url || '',
-          public_id:     result.public_id,
-          caption:       '',
-          file_size:     result.bytes || 0,
-        });
-
-        toast('✓ Hochgeladen');
-      } catch (err) {
-        toast(err.message, 'error');
-      }
-
-      if (prog) prog.style.display = 'none';
-      if (bar) bar.style.width = '0%';
+  for (const file of files) {
+    // Validate type
+    if (!ALLOWED_MEDIA_TYPES.includes(file.type)) {
+      toast(`Dateityp nicht erlaubt: ${file.type || 'unbekannt'}`, 'error');
+      continue;
+    }
+    // Validate size
+    if (file.size > MAX_FILE_SIZE) {
+      toast(`Datei zu groß: ${(file.size / 1024 / 1024).toFixed(1)} MB (max ${MAX_FILE_SIZE / 1024 / 1024} MB)`, 'error');
+      continue;
     }
 
+    const prog = document.getElementById('media-upload-progress');
+    const bar  = document.getElementById('media-upload-bar');
+    const txt  = document.getElementById('media-upload-text');
+    if (prog) prog.style.display = 'block';
+
+    try {
+      const result = await uploadToCloudinary(file, pct => {
+        if (bar) bar.style.width = pct + '%';
+        if (txt) txt.textContent = `Wird hochgeladen… ${pct}%`;
+      });
+
+      const isVideo = file.type.startsWith('video');
+      await saveTourMedia({
+        tour_id:       state.currentTourId,
+        user_id:       state.currentUser.id,
+        username:      state.currentUser.username,
+        media_type:    isVideo ? 'video' : 'image',
+        url:           result.secure_url,
+        thumbnail_url: result.eager?.[0]?.secure_url || '',
+        public_id:     result.public_id,
+        caption:       '',
+        file_size:     result.bytes || 0,
+      });
+
+      toast('✓ Hochgeladen');
+    } catch (err) {
+      toast(err.message, 'error');
+    }
+
+    if (prog) prog.style.display = 'none';
+    if (bar) bar.style.width = '0%';
+  }
+
+  // Re-render media tab
+  _refreshMediaTab();
+}
+
+function attachMediaEvents() {
+  /* File upload via file picker */
+  document.getElementById('media-file-input')?.addEventListener('change', async e => {
+    const files = [...e.target.files];
+    await _uploadTourMediaFiles(files);
     // Reset input so same file can be re-uploaded
     e.target.value = '';
-
-    // Re-render media tab
-    _refreshMediaTab();
   });
+
+  /* Drag & drop upload — Workaround für macOS-PWAs (Foto-Mediathek-Picker
+     liefert ERR_ACCESS_DENIED) und ohnehin bequemer am Desktop. */
+  const dropZone = document.querySelector('#tab-content .tab-scroll');
+  if (dropZone && !dropZone.dataset.dropAttached) {
+    dropZone.dataset.dropAttached = '1';
+    let dragDepth = 0;
+    const hasFiles = e => {
+      const types = e.dataTransfer?.types;
+      if (!types) return false;
+      // DOMStringList in some browsers — both have includes()/contains()
+      return Array.from(types).includes('Files');
+    };
+    dropZone.addEventListener('dragenter', e => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      dragDepth++;
+      _showMediaDropOverlay();
+    });
+    dropZone.addEventListener('dragover', e => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+    });
+    dropZone.addEventListener('dragleave', e => {
+      if (!hasFiles(e)) return;
+      dragDepth = Math.max(0, dragDepth - 1);
+      if (dragDepth === 0) _hideMediaDropOverlay();
+    });
+    dropZone.addEventListener('drop', async e => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      dragDepth = 0;
+      _hideMediaDropOverlay();
+      const files = [...(e.dataTransfer?.files || [])];
+      await _uploadTourMediaFiles(files);
+    });
+  }
 
   /* YouTube link toggle */
   document.getElementById('media-yt-btn')?.addEventListener('click', () => {
@@ -2338,6 +2379,19 @@ function _refreshMediaTab() {
     tc.innerHTML = renderMediaTab();
     attachMediaEvents();
   }
+}
+
+function _showMediaDropOverlay() {
+  if (document.getElementById('media-drop-overlay')) return;
+  const o = document.createElement('div');
+  o.id = 'media-drop-overlay';
+  o.className = 'media-drop-overlay';
+  o.innerHTML = '<div class="media-drop-overlay-inner">📥<br>Datei(en) hier ablegen</div>';
+  document.body.appendChild(o);
+}
+
+function _hideMediaDropOverlay() {
+  document.getElementById('media-drop-overlay')?.remove();
 }
 
 /* ----------------------------------------------------------

--- a/js/render.js
+++ b/js/render.js
@@ -3210,8 +3210,21 @@ function renderPollEditModal(poll) {
    Media Tab (Cloudinary + YouTube)
    ---------------------------------------------------------- */
 
+/**
+ * Returns true if media item `m` is new to the current user since the last
+ * snapshot — i.e. uploaded by someone else AFTER the user last opened this
+ * media view. Used to render the small "NEU" badge on cards.
+ */
+function _isNewMedia(m, snapshotMs) {
+  if (!snapshotMs || !m?.created_at) return false;
+  if (m.user_id === state.currentUser?.id) return false;
+  const t = new Date(m.created_at).getTime();
+  return Number.isFinite(t) && t > snapshotMs;
+}
+
 function renderMediaTab() {
   const media = [...state.tourMedia].sort((a, b) => (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0) || (a.sort_order || 0) - (b.sort_order || 0) || new Date(b.created_at) - new Date(a.created_at));
+  const newSnap = state.mediaSeenAt?.[`tour:${state.currentTourId}`] || 0;
   const images = media.filter(m => m.media_type === 'image');
   const videos = media.filter(m => m.media_type === 'video');
   const ytVideos = media.filter(m => m.media_type === 'youtube');
@@ -3255,6 +3268,8 @@ function renderMediaTab() {
     const dt = new Date(m.created_at);
     const dateStr = dt.toLocaleDateString('de-DE', { day:'2-digit', month:'2-digit', year:'2-digit' });
 
+    const newBadge = _isNewMedia(m, newSnap) ? '<div class="media-new-badge">NEU</div>' : '';
+
     if (m.media_type === 'image') {
       // Cloudinary thumbnail: 400px wide, auto height, auto quality
       const thumb = m.url.replace('/upload/', '/upload/c_fill,w_400,h_300,q_auto/');
@@ -3262,6 +3277,7 @@ function renderMediaTab() {
 <div class="media-card" data-media-id="${m.id}" ${isAdmin ? 'draggable="true"' : ''}>
   <div class="media-thumb" style="cursor:pointer" data-lightbox-url="${m.url}" data-lightbox-type="image">
     ${m.pinned ? '<div class="media-pinned-badge">📌</div>' : ''}
+    ${newBadge}
     <img src="${thumb}" alt="${esc(m.caption || '')}" loading="lazy" />
   </div>
   <div class="media-card-footer">
@@ -3282,6 +3298,7 @@ function renderMediaTab() {
 <div class="media-card" data-media-id="${m.id}" ${isAdmin ? 'draggable="true"' : ''}>
   <div class="media-thumb" style="cursor:pointer;position:relative" data-lightbox-url="${m.url}" data-lightbox-type="video">
     ${m.pinned ? '<div class="media-pinned-badge">📌</div>' : ''}
+    ${newBadge}
     <img src="${thumb}" alt="${esc(m.caption || '')}" loading="lazy" />
     <div class="media-play-overlay">▶</div>
   </div>
@@ -3304,6 +3321,7 @@ function renderMediaTab() {
 <div class="media-card" data-media-id="${m.id}" ${isAdmin ? 'draggable="true"' : ''}>
   <div class="media-thumb" style="cursor:pointer;position:relative" data-lightbox-url="${m.url}" data-lightbox-type="youtube" data-yt-id="${ytId}">
     ${m.pinned ? '<div class="media-pinned-badge">📌</div>' : ''}
+    ${newBadge}
     <img src="${thumb}" alt="${esc(m.caption || '')}" loading="lazy" />
     <div class="media-play-overlay">▶</div>
   </div>
@@ -3364,10 +3382,22 @@ function renderMediaLightbox(url, type, ytId, mediaId) {
    ---------------------------------------------------------- */
 
 function renderCommunityMedia() {
-  const tours = state.tours || [];
   const isAdmin = state.currentCommunity &&
     (state.currentCommunity.admin_id === state.currentUser.id ||
      (state.currentCommunity.co_admin_ids || []).includes(state.currentUser.id));
+
+  // Tour-Sidebar: vergangene Touren oben (neueste zuerst), zukünftige unten
+  // (nächste zuerst). Touren ohne Datum sortieren ans Ende.
+  const todayStart = new Date(); todayStart.setHours(0,0,0,0);
+  const past = [], future = [], undated = [];
+  for (const t of (state.tours || [])) {
+    if (!t.date) { undated.push(t); continue; }
+    const d = new Date(t.date + 'T12:00:00');
+    (d < todayStart ? past : future).push(t);
+  }
+  past.sort((a, b) => new Date(b.date) - new Date(a.date));   // newest past first
+  future.sort((a, b) => new Date(a.date) - new Date(b.date)); // soonest future first
+  const tours = [...past, ...future, ...undated];
 
   // Tour list sidebar
   const tourList = tours.length === 0
@@ -3436,11 +3466,14 @@ function _renderCommunityMediaCard(m, isAdmin) {
   const dateStr = dt.toLocaleDateString('de-DE', { day:'2-digit', month:'2-digit', year:'2-digit' });
   const isMe = m.user_id === state.currentUser.id;
   const canDelete = isMe || isAdmin;
+  const newSnap = state.mediaSeenAt?.[`cm:${state.currentCommunityId}`] || 0;
+  const newBadge = _isNewMedia(m, newSnap) ? '<div class="media-new-badge">NEU</div>' : '';
 
   return `
 <div class="media-card" data-media-id="${m.id}" ${isAdmin ? 'draggable="true"' : ''}>
   <div class="media-thumb" style="cursor:pointer;position:relative" data-cm-lightbox-url="${m.url}" data-cm-lightbox-type="youtube" data-cm-yt-id="${ytId || ''}">
     ${m.pinned ? '<div class="media-pinned-badge">📌</div>' : ''}
+    ${newBadge}
     <img src="${thumb}" alt="${esc(m.caption || '')}" loading="lazy" />
     <div class="media-play-overlay">▶</div>
   </div>
@@ -3461,14 +3494,18 @@ function renderTourMediaPreview(media) {
     return '<div style="text-align:center;padding:40px;color:var(--muted)">Keine Medien in dieser Tour.</div>';
   }
 
+  const newSnap = state.mediaSeenAt?.[`tm:${state.currentCommunityId}`] || 0;
+
   const gallery = media.map(m => {
     const dt = new Date(m.created_at);
     const dateStr = dt.toLocaleDateString('de-DE', { day:'2-digit', month:'2-digit', year:'2-digit' });
+    const newBadge = _isNewMedia(m, newSnap) ? '<div class="media-new-badge">NEU</div>' : '';
 
     if (m.media_type === 'image') {
       const thumb = m.url.replace('/upload/', '/upload/c_fill,w_400,h_300,q_auto/');
-      return `<div class="media-card" data-media-id="${m.id}"><div class="media-thumb" style="cursor:pointer" data-cm-lightbox-url="${m.url}" data-cm-lightbox-type="image">
+      return `<div class="media-card" data-media-id="${m.id}"><div class="media-thumb" style="cursor:pointer;position:relative" data-cm-lightbox-url="${m.url}" data-cm-lightbox-type="image">
         ${m.pinned ? '<div class="media-pinned-badge">📌</div>' : ''}
+        ${newBadge}
         <img src="${thumb}" loading="lazy" /></div>
         <div class="media-card-footer"><div class="media-card-info"><span class="media-card-user">${esc(m.username)}</span><span class="media-card-date">${dateStr}</span></div>
         ${m.caption ? `<div class="media-card-caption">${esc(m.caption)}</div>` : ''}</div></div>`;
@@ -3477,6 +3514,7 @@ function renderTourMediaPreview(media) {
       const thumb = m.thumbnail_url || m.url.replace('/upload/', '/upload/c_fill,w_400,h_300,so_1/');
       return `<div class="media-card" data-media-id="${m.id}"><div class="media-thumb" style="cursor:pointer;position:relative" data-cm-lightbox-url="${m.url}" data-cm-lightbox-type="video">
         ${m.pinned ? '<div class="media-pinned-badge">📌</div>' : ''}
+        ${newBadge}
         <img src="${thumb}" loading="lazy" /><div class="media-play-overlay">▶</div></div>
         <div class="media-card-footer"><div class="media-card-info"><span class="media-card-user">${esc(m.username)}</span><span class="media-card-date">${dateStr}</span></div>
         ${m.caption ? `<div class="media-card-caption">${esc(m.caption)}</div>` : ''}</div></div>`;
@@ -3486,6 +3524,7 @@ function renderTourMediaPreview(media) {
       const thumb = m.thumbnail_url || `https://img.youtube.com/vi/${ytId}/hqdefault.jpg`;
       return `<div class="media-card" data-media-id="${m.id}"><div class="media-thumb" style="cursor:pointer;position:relative" data-cm-lightbox-url="${m.url}" data-cm-lightbox-type="youtube" data-cm-yt-id="${ytId}">
         ${m.pinned ? '<div class="media-pinned-badge">📌</div>' : ''}
+        ${newBadge}
         <img src="${thumb}" loading="lazy" /><div class="media-play-overlay">▶</div></div>
         <div class="media-card-footer"><div class="media-card-info"><span class="media-card-user">${esc(m.username)}</span><span class="media-card-date">${dateStr}</span></div>
         ${m.caption ? `<div class="media-card-caption">${esc(m.caption)}</div>` : ''}</div></div>`;

--- a/js/state.js
+++ b/js/state.js
@@ -59,6 +59,11 @@ const state = {
   mediaBadges:    { community: 0, tours: 0 },
   tourMediaCounts: {},
   tourMediaNew:    {},
+  // Snapshot der zuletzt-gesehen-Zeitpunkte beim Öffnen einer Media-Ansicht.
+  // Wird benutzt um pro Item ein "NEU"-Label zu zeigen, OHNE dass markTabSeen
+  // (das gleich danach läuft) das Label sofort wieder verschwinden lässt.
+  // Keys: `tour:<tourId>` | `cm:<cid>` | `tm:<cid>`  → Wert: ms since epoch
+  mediaSeenAt:     {},
   isSiteAdminUser: false,   // tour id selected in community media view
   tabBadges:     {},
   tourCalMonth:  null,

--- a/supabase/migrations/20260508220314_remote_history_placeholder.sql
+++ b/supabase/migrations/20260508220314_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.

--- a/supabase/migrations/20260509081130_remote_history_placeholder.sql
+++ b/supabase/migrations/20260509081130_remote_history_placeholder.sql
@@ -1,0 +1,1 @@
+-- Placeholder for remote migration history already applied in Supabase.


### PR DESCRIPTION
## Summary

- **Drag-and-drop file upload** on the tour Media tab. Works around a macOS Chrome PWA quirk where the Photos-library picker silently fails with `ERR_ACCESS_DENIED` — drag from Photos.app into the window now uploads directly.
- **Per-card NEU badge** on tour media, community library, and tour-preview cards. A seen-state snapshot is frozen *before* `markTabSeen` runs, so the per-item badges stay visible during the visit and only clear on the next entry.
- **Own uploads no longer count toward media banner counts** — `computeMediaBadges` and the per-tour `computeTabBadges` media path now exclude `state.currentUser.id`, matching what `computeTourMediaCounts` already did.
- **Community Media sidebar tour sort** changed: past tours first (newest at top), future tours below (soonest first), undated last.

Also bundles the previously committed `Add missing remote migration placeholders`.

## Test plan

- [ ] Mac Chrome PWA: drag a photo from Photos.app onto the tour Media tab → uploads successfully
- [ ] Friend uploads a file → orange "NEU" badge appears on that card until you reopen the Media tab in a separate visit
- [ ] You upload a file yourself → no Media banner shows on Community Home afterward
- [ ] Community Media sidebar: past tours appear at top in reverse-chronological order; upcoming tours below

🤖 Generated with [Claude Code](https://claude.com/claude-code)